### PR TITLE
chore(https): enable https server

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,5 @@ $ cd backend/
 ```
 Generate a certificate and key.
 ```bash
-$ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
+$ sh ../scripts/generate-cert.sh $IP_ADDRESS
 ```
-Use the passphrase `vanroomies`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # VanRoomies
 A match-making housing app
+
+## BACKEND 
+### Development
+#### Set up development key and cert
+**Linux**
+Change directory into backend.
+```bash
+$ cd backend/
+```
+Generate a certificate and key.
+```bash
+$ openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365
+```
+Use the passphrase `vanroomies`.

--- a/backend/.env
+++ b/backend/.env
@@ -1,1 +1,0 @@
-MONGODB_TEST_URI='mongodb://localhost:27017/testdb'

--- a/backend/.env.development
+++ b/backend/.env.development
@@ -1,2 +1,4 @@
 MONGODB_TEST_URI='mongodb://localhost:27017/testdb'
-PASSPHRASE=vanroomies
+CERT_PATH=certs/cert.pem
+KEY_PATH=certs/key.pem
+

--- a/backend/.env.development
+++ b/backend/.env.development
@@ -1,0 +1,2 @@
+MONGODB_TEST_URI='mongodb://localhost:27017/testdb'
+PASSPHRASE=vanroomies

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .env
 .eslintcache
+*.pem

--- a/backend/certs/README.md
+++ b/backend/certs/README.md
@@ -1,0 +1,1 @@
+# Directory to hold secrets

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "description": "Backend of VanRoomies project.",
   "main": "server.js",
   "scripts": {
-    "start": "node src/app.js",
-    "dev": "nodemon src/app.js",
+    "start": "NODE_ENV=production node src/app.js",
+    "dev": "NODE_ENV=development nodemon src/app.js",
     "lint": "concurrently -c 'auto' 'npm:eslint' 'npm:prettier'",
     "prettier": "prettier --write './src/**/*.js'",
     "eslint": "eslint --cache --ext .js ./src/"

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -2,12 +2,21 @@ const dotenv = require('dotenv');
 const express = require('express');
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
-
-const app = express();
-const port = 3000;
+const https = require('https');
+const fs = require('fs');
 
 // Configure environment variable path
-dotenv.config({ path: '.env' });
+require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}` })
+
+const app = express();
+const credentials = {
+	key: fs.readFileSync('key.pem'),
+	cert: fs.readFileSync('cert.pem'),
+	passphrase: process.env.PASSPHRASE
+};
+
+const httpsServer = https.createServer(credentials, app);
+const port = 3000;
 
 function logErrors(err, req, res, next) {
     console.error(err.message);
@@ -51,6 +60,6 @@ app.get('/', (req, res) => {
 app.use(logErrors);
 app.use(errorHandler);
 
-app.listen(port, () => {
+httpsServer.listen(port, () => {
     console.log(`Example app listening on port ${port}`);
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,18 +1,17 @@
-const dotenv = require('dotenv');
 const express = require('express');
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
 const https = require('https');
 const fs = require('fs');
+const path = require('path');
 
 // Configure environment variable path
 require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}` })
 
 const app = express();
 const credentials = {
-	key: fs.readFileSync('key.pem'),
-	cert: fs.readFileSync('cert.pem'),
-	passphrase: process.env.PASSPHRASE
+	key: fs.readFileSync(path.resolve(process.env.KEY_PATH)),
+	cert: fs.readFileSync(path.resolve(process.env.CERT_PATH)),
 };
 
 const httpsServer = https.createServer(credentials, app);

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Generate a self-signed certificate for a given IP address
+# Credit to https://medium.com/@antelle/how-to-generate-a-self-signed-ssl-certificate-for-an-ip-address-f0dd8dddf754
+
+# Usage example:
+# sh generate-ip-cert.sh 127.0.0.1
+
+IP=$1
+if [ -z "$IP" ]; then
+	IP="127.0.0.1"
+fi
+
+echo "Generating certificate for $IP"
+
+curl -sS https://raw.githubusercontent.com/antelle/generate-ip-cert/master/generate-ip-cert.sh | bash -s $IP

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -10,7 +10,12 @@ IP=$1
 if [ -z "$IP" ]; then
 	IP="127.0.0.1"
 fi
+DIR=$(dirname $(readlink -f $0))
+mkdir -p $DIR/../backend/certs
+cd $DIR/../backend/certs
 
 echo "Generating certificate for $IP"
 
 curl -sS https://raw.githubusercontent.com/antelle/generate-ip-cert/master/generate-ip-cert.sh | bash -s $IP
+
+cd -


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #31 

## Description of the change:
This change allows HTTPS to be enabled for the Express server.

## How to manually test:
1. Follow readme for how to generate self signed certs for development.
2. `npm run dev`
