### PR TITLE
chore(dev): add cross-env to backend for cross-compatibility

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "concurrently": "^8.2.1",
+        "cross-env": "^7.0.3",
         "eslint": "^8.51.0",
         "nodemon": "^3.0.1",
         "prettier": "3.0.3"
@@ -623,6 +624,24 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,8 +4,8 @@
   "description": "Backend of VanRoomies project.",
   "main": "server.js",
   "scripts": {
-    "start": "NODE_ENV=production node src/app.js",
-    "dev": "NODE_ENV=development nodemon src/app.js",
+    "start": "cross-env NODE_ENV=production node src/app.js",
+    "dev": "cross-env NODE_ENV=development nodemon src/app.js",
     "lint": "concurrently -c 'auto' 'npm:eslint' 'npm:prettier'",
     "prettier": "prettier --write './src/**/*.js'",
     "eslint": "eslint --cache --ext .js ./src/"
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "concurrently": "^8.2.1",
+    "cross-env": "^7.0.3",
     "eslint": "^8.51.0",
     "nodemon": "^3.0.1",
     "prettier": "3.0.3"


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

## Description of the change:
This change allows us to run the backend start scripts on any platform, including Windows using the NODE_ENV variable.

## How to manually test:
1. `npm install`
2. Use Windows.
3. run `npm run dev`
4. Use Linux
5. run `npm run dev`
