### PR TITLE
feat(view listing): Implement and Integrate Frontend ViewListing Activity

### DIFF
--- a/frontend/app/src/main/AndroidManifest.xml
+++ b/frontend/app/src/main/AndroidManifest.xml
@@ -12,12 +12,15 @@
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
-        android:networkSecurityConfig="@xml/network_security_config"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.VanRoomies"
         tools:targetApi="31">
+        <activity
+            android:name=".ViewListingActivity"
+            android:exported="false" />
         <activity
             android:name=".HomeActivity"
             android:exported="false" />

--- a/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
@@ -5,7 +5,8 @@ public class Constants {
     final static String baseServerURL = "https://10.0.2.2:3000";
     // final static String baseServerURL = "Insert VM Server URL";
     final static String helloWorldEndpoint = "/"; // GET
-    final static String listingByUserIdEndpoint = "/api/listings/user/"; // GET, needs listing_id appended
+    final static String listingByUserIdEndpoint = "/api/listings/user/"; // GET, needs user_id appended
+    final static String listingByListingIdEndpoint = "/api/listings/"; // GET/PUT, needs listing_id appended
 
 
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
@@ -126,6 +126,7 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
                             // Information taken to individual listing
                             String listing_id = listing_obj.getString("_id");
                             HashMap<String, String> additionalInfo = new HashMap<>();
+                            additionalInfo.put("owner_id", listing_obj.getString("userId"));
                             additionalInfo.put("description", listing_obj.getString("description"));
                             additionalInfo.put("housingType", listing_obj.getString("housingType"));
                             additionalInfo.put("listingDate", listing_obj.getString("listingDate"));
@@ -159,6 +160,7 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
     public void onItemClicked(ListingsRecyclerData recyclerData) {
         Intent intent = new Intent(getActivity(), ViewListingActivity.class);
         Bundle b = new Bundle();
+        b.putString("listing_id", recyclerData.getListingId());
         b.putString("title", recyclerData.getTitle());
         b.putString("photo_string", recyclerData.getImageString());
         b.putSerializable("info", recyclerData.getAdditionalInfo());

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
@@ -1,6 +1,8 @@
 package com.chads.vanroomies;
 
 import android.app.Activity;
+
+import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -21,6 +23,7 @@ import org.json.JSONObject;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -35,7 +38,7 @@ import okhttp3.Response;
  * Use the {@link ListingsFragment#newInstance} factory method to
  * create an instance of this fragment.
  */
-public class ListingsFragment extends Fragment {
+public class ListingsFragment extends Fragment implements ListingsItemSelectListener{
     final static String TAG = "ListingsFragment";
     private OkHttpClient httpClient;
     final static Gson g = new Gson();
@@ -115,13 +118,25 @@ public class ListingsFragment extends Fragment {
                         for (int index = 0; index < responseDataList.size(); index++){
                             Map<String, Object> listingJson = responseDataList.get(index);
                             JSONObject listing_obj = new JSONObject(listingJson);
+
+                            // Information shown in list
                             String listing_title = listing_obj.getString("title");
                             String listing_photo = listing_obj.getJSONArray("images").get(0).toString();
-                            recyclerDataArrayList.add(new ListingsRecyclerData(listing_title, listing_photo));
+
+                            // Information taken to individual listing
+                            String listing_id = listing_obj.getString("_id");
+                            HashMap<String, String> additionalInfo = new HashMap<>();
+                            additionalInfo.put("description", listing_obj.getString("description"));
+                            additionalInfo.put("housingType", listing_obj.getString("housingType"));
+                            additionalInfo.put("listingDate", listing_obj.getString("listingDate"));
+                            additionalInfo.put("moveInDate", listing_obj.getString("moveInDate"));
+                            additionalInfo.put("petFriendly", listing_obj.getString("petFriendly"));
+
+                            recyclerDataArrayList.add(new ListingsRecyclerData(listing_title, listing_photo, listing_id, additionalInfo));
                         }
 
                         // added data from arraylist to adapter class.
-                        ListingsRecyclerViewAdapter adapter = new ListingsRecyclerViewAdapter(recyclerDataArrayList, view.getContext());
+                        ListingsRecyclerViewAdapter adapter = new ListingsRecyclerViewAdapter(recyclerDataArrayList, ListingsFragment.this, view.getContext());
 
                         // setting grid layout manager to implement grid view.
                         // in this method '2' represents number of columns to be displayed in grid view.
@@ -138,5 +153,17 @@ public class ListingsFragment extends Fragment {
                 });
             }
         });
+    }
+
+    @Override
+    public void onItemClicked(ListingsRecyclerData recyclerData) {
+        Intent intent = new Intent(getActivity(), ViewListingActivity.class);
+        Bundle b = new Bundle();
+        b.putString("title", recyclerData.getTitle());
+        b.putString("photo_string", recyclerData.getImageString());
+        b.putSerializable("info", recyclerData.getAdditionalInfo());
+        intent.putExtras(b);
+
+        startActivity(intent);
     }
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsItemSelectListener.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsItemSelectListener.java
@@ -1,0 +1,5 @@
+package com.chads.vanroomies;
+
+public interface ListingsItemSelectListener {
+    void onItemClicked(ListingsRecyclerData recyclerData);
+}

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsRecyclerData.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsRecyclerData.java
@@ -1,8 +1,14 @@
 package com.chads.vanroomies;
+
+import java.util.HashMap;
+import java.util.Map;
+
 // Reference: https://www.geeksforgeeks.org/recyclerview-using-gridlayoutmanager-in-android-with-example/
 public class ListingsRecyclerData {
     private String title;
     private String imageString;
+    private String listingId;
+    private HashMap<String, String> additionalInfo;
 
     public String getTitle() {
         return title;
@@ -19,10 +25,24 @@ public class ListingsRecyclerData {
     public void setImageString(int imgId) {
         this.imageString = imageString;
     }
+    public String getListingId() {
+        return listingId;
+    }
+    public void setListingId(String id) {
+        this.listingId = id;
+    }
+    public HashMap<String, String> getAdditionalInfo() {
+        return additionalInfo;
+    }
+    public void setAdditionalInfo(HashMap<String, String> info) {
+        this.additionalInfo = info;
+    }
 
-    public ListingsRecyclerData(String title, String imageString) {
+    public ListingsRecyclerData(String title, String imageString, String listingId, HashMap<String, String> additionalInfo) {
         this.title = title;
         this.imageString = imageString;
+        this.listingId = listingId;
+        this.additionalInfo = additionalInfo;
     }
 
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsRecyclerViewAdapter.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsRecyclerViewAdapter.java
@@ -10,16 +10,20 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.cardview.widget.CardView;
 import androidx.recyclerview.widget.RecyclerView;
 import java.util.ArrayList;
 
 public class ListingsRecyclerViewAdapter extends RecyclerView.Adapter<ListingsRecyclerViewAdapter.RecyclerViewHolder> {
 
     private ArrayList<ListingsRecyclerData> listingsDataArrayList;
+    private ListingsItemSelectListener listener;
+
     private Context mcontext;
 
-    public ListingsRecyclerViewAdapter(ArrayList<ListingsRecyclerData> recyclerDataArrayList, Context mcontext) {
+    public ListingsRecyclerViewAdapter(ArrayList<ListingsRecyclerData> recyclerDataArrayList, ListingsItemSelectListener listener, Context mcontext) {
         this.listingsDataArrayList = recyclerDataArrayList;
+        this.listener = listener;
         this.mcontext = mcontext;
     }
 
@@ -40,6 +44,13 @@ public class ListingsRecyclerViewAdapter extends RecyclerView.Adapter<ListingsRe
         byte[] decodedString = Base64.decode(recyclerData.getImageString(), Base64.DEFAULT);
         Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
         holder.listingIV.setImageBitmap(decodedByte);
+
+        holder.listingCard.setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View view){
+                listener.onItemClicked(recyclerData);
+            }
+        });
     }
 
     @Override
@@ -52,11 +63,14 @@ public class ListingsRecyclerViewAdapter extends RecyclerView.Adapter<ListingsRe
 
         private TextView listingTV;
         private ImageView listingIV;
+        private CardView listingCard;
 
         public RecyclerViewHolder(@NonNull View itemView) {
             super(itemView);
             listingTV = itemView.findViewById(R.id.idTVListing);
             listingIV = itemView.findViewById(R.id.idIVListing);
+            listingCard = itemView.findViewById(R.id.listingCard);
         }
+
     }
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/SingleListingResponseResult.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/SingleListingResponseResult.java
@@ -1,0 +1,141 @@
+package com.chads.vanroomies;
+
+import android.location.Location;
+
+import java.util.List;
+
+public class SingleListingResponseResult {
+
+    private String _id;
+    private String userId;
+    private String title;
+    private String description;
+    private String housingType;
+    private int rentalPrice;
+
+    private String listingDate;
+    private String moveInDate;
+    private boolean petFriendly;
+    private LocationObj location;
+    private List<String> images;
+
+    public String get_id() {
+        return _id;
+    }
+
+    public void set_id(String _id) {
+        this._id = _id;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+
+    public String getHousingType() {
+        return housingType;
+    }
+
+    public void setHousingType(String housingType) {
+        this.housingType = housingType;
+    }
+
+
+    public int getRentalPrice() {
+        return rentalPrice;
+    }
+
+    public void setRentalPrice(int rentalPrice) {
+        this.rentalPrice = rentalPrice;
+    }
+
+    public String getListingDate() {
+        return listingDate;
+    }
+
+    public void setListingDate(String listingDate) {
+        this.listingDate = listingDate;
+    }
+
+    public String getMoveInDate() {
+        return moveInDate;
+    }
+
+    public void setMoveInDate(String moveInDate) {
+        this.moveInDate = moveInDate;
+    }
+
+    public Boolean getPetFriendly() {
+        return petFriendly;
+    }
+
+    public void setPetFriendly(Boolean petFriendly) {
+        this.petFriendly = petFriendly;
+    }
+
+    public LocationObj getLocation() {
+        return location;
+    }
+
+    public void setLocation(LocationObj location) {
+        this.location = location;
+    }
+
+    public List<String> getImages() {
+        return images;
+    }
+
+    public void setImages(List<String> images) {
+        this.images = images;
+    }
+
+    public static class LocationObj {
+        private int latitude;
+        private int longitude;
+        private String _id;
+
+        public int getLatitude() {
+            return latitude;
+        }
+
+        public void setLatitude(int latitude) {
+            this.latitude = latitude;
+        }
+
+        public int getLongitude() {
+            return longitude;
+        }
+
+        public void setLongitude(int longitude) {
+            this.longitude = longitude;
+        }
+
+        public String get_id() {
+            return _id;
+        }
+
+        public void set_id(String _id) {
+            this._id = _id;
+        }
+    }
+}

--- a/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
@@ -1,66 +1,274 @@
 package com.chads.vanroomies;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import java.util.HashMap;
+import com.google.gson.Gson;
+
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class ViewListingActivity extends AppCompatActivity {
     final static String TAG = "ViewListing";
+    OkHttpClient client;
+    String userId = "65402f35e10ec75253936947"; // TODO: Track userId instead of hardcoding
+    static boolean isOwner = false;
+    final static Gson g = new Gson();
+
+    private Button editTitleButton;
+    private Button editHousingDescButton;
+    private Button editHousingTypeButton;
+    private Button togglePetFriendlyButton;
+    private Button editMoveInButton;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_view_listing);
 
+        // Grabbing parameters from listings view
         Bundle b = getIntent().getExtras();
+        client = HTTPSClientFactory.createClient(ViewListingActivity.this.getApplication());
         if(b != null) {
-            // Fetching Parameters
-            HashMap<String, String> info = (HashMap<String, String>) b.getSerializable("info");
-            String photo_string = b.getString("photo_string");
-            String title = b.getString("title");
-            String description = info.get("description");
-            String housingType = info.get("housingType");
-            String listingDate = info.get("listingDate").split(getString(R.string.datetime_regex), 2)[0];;
-            String moveInDate = info.get("moveInDate").split(getString(R.string.datetime_regex), 2)[0];
-            String petFriendly = info.get("petFriendly");
-
-            // Instantiating TextViews
-            ImageView listing_image = findViewById(R.id.listing_picture);
-            TextView title_textview = findViewById(R.id.listing_name);
-            TextView description_textview = findViewById(R.id.listing_desc);
-            TextView housing_type_textview = findViewById(R.id.housing_type);
-            TextView listing_date_textview = findViewById(R.id.listing_date);
-            TextView move_in_date_textview = findViewById(R.id.move_in_date);
-            TextView pet_textview = findViewById(R.id.pet_friendly);
-
-            // Setting ImageView
-            byte[] decodedString = Base64.decode(photo_string, Base64.DEFAULT);
-            Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
-            listing_image.setImageBitmap(decodedByte);
-
-            // Setting TextViews
-            title_textview.setText(title);
-            description_textview.setText(description);
-            housing_type_textview.setText(housingType);
-            listing_date_textview.setText(String.format("%s %s", getString(R.string.posted), listingDate));
-            move_in_date_textview.setText(String.format("%s %s", getString(R.string.move), moveInDate));
-
-            Log.d(TAG, listingDate);
-            Log.d(TAG, moveInDate);
-            Log.d(TAG, petFriendly);
-            if(petFriendly.equals("true")){
-                pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.allowed)));
-            }
-            else {
-                pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.not_allowed)));
-            }
+            String listing_id = b.getString("listing_id");
+            getListing(client, listing_id);
         }
+    }
+
+    public void enableButton(Button button, String attribute, TextView text_field, String listing_id){
+        button.setEnabled(true);
+        button.setVisibility(View.VISIBLE);
+        // Set Listener
+        button.setOnClickListener(view -> {
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(view.getContext());
+            // Initialize the edit box
+            final EditText et = new EditText(view.getContext());
+            et.setText(text_field.getText());
+            et.setHeight(pxFromDp(view.getContext(), 250));
+            alertDialogBuilder.setView(et);
+
+            alertDialogBuilder.setCancelable(true).setPositiveButton("Save", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                    try {
+                        updateEditableText(client, view, ViewListingActivity.this, attribute, listing_id, text_field, et.getText().toString());
+                    } catch (JSONException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }).setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                }
+            });
+            AlertDialog alertDialog = alertDialogBuilder.create();
+            alertDialog.show();
+        });
+    }
+
+    public void enableToggle(Button button, String attribute, TextView text_field, String listing_id){
+        button.setEnabled(true);
+        button.setVisibility(View.VISIBLE);
+        // Set Listener
+        button.setOnClickListener(view -> {
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(view.getContext());
+            alertDialogBuilder
+                    .setCancelable(true)
+                    .setTitle("Are pets allowed?")
+                    .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+
+                    // Setting up a PUT request
+                    RequestBody formBody = new FormBody.Builder()
+                            .add(attribute, "true")
+                            .build();
+                    Request request = new Request.Builder()
+                            .url(Constants.baseServerURL + Constants.listingByListingIdEndpoint + listing_id)
+                            .put(formBody) // PUT
+                            .build();
+                    client.newCall(request).enqueue(new Callback() {
+                        @Override
+                        public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                            Log.d(TAG, e.getMessage());
+                        }
+
+                        @Override
+                        public void onResponse(@NonNull Call call, @NonNull Response response) {
+                        }
+                    });
+                    // Change to allowed
+                    text_field.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.allowed)));
+                }
+            }).setNegativeButton("No", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                    // Setting up a PUT request
+                    RequestBody formBody = new FormBody.Builder()
+                            .add(attribute, "false")
+                            .build();
+                    Request request = new Request.Builder()
+                            .url(Constants.baseServerURL + Constants.listingByListingIdEndpoint + listing_id)
+                            .put(formBody) // PUT
+                            .build();
+                    client.newCall(request).enqueue(new Callback() {
+                        @Override
+                        public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                            Log.d(TAG, e.getMessage());
+                        }
+
+                        @Override
+                        public void onResponse(@NonNull Call call, @NonNull Response response) {
+                        }
+                    });
+                    text_field.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.not_allowed)));
+                }
+            });
+            AlertDialog alertDialog = alertDialogBuilder.create();
+            alertDialog.show();
+        });
+    }
+
+    public void disableButton(Button button){
+        button.setEnabled(false);
+        button.setVisibility(View.INVISIBLE);
+    }
+
+    public void updateEditableText(OkHttpClient client, View view, Activity act, String field, String listing_id, TextView textview_to_update, String new_text) throws JSONException {
+        // Setting up the request
+        RequestBody formBody = new FormBody.Builder()
+                .add(field, new_text)
+                .build();
+        Request request = new Request.Builder()
+                .url(Constants.baseServerURL + Constants.listingByListingIdEndpoint + listing_id)
+                .put(formBody) // PUT
+                .build();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                Log.d(TAG, e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                act.runOnUiThread(() -> {
+                    Log.d(TAG, response.toString());
+                    textview_to_update.setText(new_text);
+                });
+            }
+        });
+    }
+    public static int pxFromDp(Context context, float dp) {
+        return (int)(dp * context.getResources().getDisplayMetrics().density);
+    }
+
+    public void getListing(OkHttpClient client, String listing_id){
+        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByListingIdEndpoint + listing_id).build();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                Log.d(TAG, e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                runOnUiThread(() -> {
+                    try {
+                        String responseData = response.body().string();
+                        // Fetched listing information
+                        SingleListingResponseResult result = g.fromJson(responseData, SingleListingResponseResult.class);
+
+                        // Checking if Current User is the Owner
+                        isOwner = (Objects.equals(result.getUserId(), userId));
+                        Log.d(TAG, String.valueOf(isOwner));
+
+
+                        // Fetching Parameters
+                        String photo_string = result.getImages().get(0);
+                        String title = result.getTitle();
+                        String description = result.getDescription();
+                        String housingType = result.getHousingType();
+                        String listingDate = result.getListingDate().split(getString(R.string.datetime_regex), 2)[0];
+                        String moveInDate = result.getMoveInDate().split(getString(R.string.datetime_regex), 2)[0];
+                        String petFriendly = String.valueOf(result.getPetFriendly());
+
+                        // Instantiating TextViews
+                        ImageView listing_image = findViewById(R.id.listing_picture);
+                        TextView title_textview = findViewById(R.id.listing_name);
+                        TextView description_textview = findViewById(R.id.listing_desc);
+                        TextView housing_type_textview = findViewById(R.id.housing_type);
+                        TextView listing_date_textview = findViewById(R.id.listing_date);
+                        TextView move_in_date_textview = findViewById(R.id.move_in_date);
+                        TextView pet_textview = findViewById(R.id.pet_friendly);
+
+                        // Setting ImageView
+                        byte[] decodedString = Base64.decode(photo_string, Base64.DEFAULT);
+                        Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
+                        listing_image.setImageBitmap(decodedByte);
+
+                        // Setting TextViews
+                        title_textview.setText(title);
+                        description_textview.setText(description);
+                        housing_type_textview.setText(housingType);
+                        listing_date_textview.setText(String.format("%s %s", getString(R.string.posted), listingDate));
+                        move_in_date_textview.setText(String.format("%s %s", getString(R.string.move), moveInDate));
+                        if(petFriendly.equals("true")){
+                            pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.allowed)));
+                        }
+                        else {
+                            pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.not_allowed)));
+                        }
+
+                        editTitleButton = findViewById(R.id.edit_title);
+                        editHousingDescButton = findViewById(R.id.edit_housing_desc);
+                        editHousingTypeButton = findViewById(R.id.edit_housing_type);
+                        togglePetFriendlyButton = findViewById(R.id.edit_pet_friendly);
+                        editMoveInButton = findViewById(R.id.edit_move_in_button);
+                        disableButton(editMoveInButton);
+                        if(!isOwner) {
+                            disableButton(editTitleButton);
+                            disableButton(editHousingDescButton);
+                            disableButton(editHousingTypeButton);
+                            disableButton(togglePetFriendlyButton);
+                            // TODO: In future milestones, implement a way to change Move-In Date and Image
+                            // disableButton(editMoveInButton);
+                        }
+                        else {
+                            enableButton(editTitleButton, "title", title_textview, listing_id);
+                            enableButton(editHousingDescButton, "description", description_textview, listing_id);
+                            enableButton(editHousingTypeButton, "housingType", housing_type_textview, listing_id);
+                            enableToggle(togglePetFriendlyButton, "petFriendly", pet_textview, listing_id);
+                            // enableButton(editMoveInButton, "moveInDate", move_in_date_textview, listing_id);
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+            }
+        });
     }
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
@@ -1,0 +1,66 @@
+package com.chads.vanroomies;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.util.Base64;
+import android.util.Log;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.HashMap;
+
+public class ViewListingActivity extends AppCompatActivity {
+    final static String TAG = "ViewListing";
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_view_listing);
+
+        Bundle b = getIntent().getExtras();
+        if(b != null) {
+            // Fetching Parameters
+            HashMap<String, String> info = (HashMap<String, String>) b.getSerializable("info");
+            String photo_string = b.getString("photo_string");
+            String title = b.getString("title");
+            String description = info.get("description");
+            String housingType = info.get("housingType");
+            String listingDate = info.get("listingDate").split(getString(R.string.datetime_regex), 2)[0];;
+            String moveInDate = info.get("moveInDate").split(getString(R.string.datetime_regex), 2)[0];
+            String petFriendly = info.get("petFriendly");
+
+            // Instantiating TextViews
+            ImageView listing_image = findViewById(R.id.listing_picture);
+            TextView title_textview = findViewById(R.id.listing_name);
+            TextView description_textview = findViewById(R.id.listing_desc);
+            TextView housing_type_textview = findViewById(R.id.housing_type);
+            TextView listing_date_textview = findViewById(R.id.listing_date);
+            TextView move_in_date_textview = findViewById(R.id.move_in_date);
+            TextView pet_textview = findViewById(R.id.pet_friendly);
+
+            // Setting ImageView
+            byte[] decodedString = Base64.decode(photo_string, Base64.DEFAULT);
+            Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
+            listing_image.setImageBitmap(decodedByte);
+
+            // Setting TextViews
+            title_textview.setText(title);
+            description_textview.setText(description);
+            housing_type_textview.setText(housingType);
+            listing_date_textview.setText(String.format("%s %s", getString(R.string.posted), listingDate));
+            move_in_date_textview.setText(String.format("%s %s", getString(R.string.move), moveInDate));
+
+            Log.d(TAG, listingDate);
+            Log.d(TAG, moveInDate);
+            Log.d(TAG, petFriendly);
+            if(petFriendly.equals("true")){
+                pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.allowed)));
+            }
+            else {
+                pet_textview.setText(String.format("%s %s", getString(R.string.pets), getString(R.string.not_allowed)));
+            }
+        }
+    }
+}

--- a/frontend/app/src/main/res/drawable/ic_edit.xml
+++ b/frontend/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/frontend/app/src/main/res/layout/activity_view_listing.xml
+++ b/frontend/app/src/main/res/layout/activity_view_listing.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ViewListingActivity">
+
+
+    <RelativeLayout
+        android:id="@+id/relativeLayout"
+        android:layout_width="match_parent"
+        android:layout_height="350dp"
+        android:background="#D2E2E0"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.002">
+
+        <ImageView
+            android:id="@+id/listing_picture"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_alignParentBottom="true"
+            android:layout_marginBottom="-1dp"
+            android:contentDescription="@string/listing_image_desc"
+            tools:srcCompat="@tools:sample/avatars" />
+    </RelativeLayout>
+
+    <TextView
+        android:id="@+id/housing_type"
+        android:layout_width="180dp"
+        android:layout_height="35dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/housing_type"
+        android:fontFamily="sans-serif"
+        android:text="@string/housing_type"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.121"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.078" />
+
+    <TextView
+        android:id="@+id/pet_friendly"
+        android:layout_width="180dp"
+        android:layout_height="35dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/pet_friendly"
+        android:fontFamily="sans-serif"
+        android:gravity="end"
+        android:text="@string/pet_friendly"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.93"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.078" />
+
+    <TextView
+        android:id="@+id/listing_name"
+        android:layout_width="304dp"
+        android:layout_height="35dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/listing_name_desc"
+        android:fontFamily="sans-serif"
+        android:text="@string/listing_name"
+        android:textSize="28sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.261"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.136" />
+
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardView"
+        android:layout_width="355dp"
+        android:layout_height="201dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        app:cardBackgroundColor="#FFFFFF"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.495"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/listing_name"
+        app:layout_constraintVertical_bias="0.18">
+
+        <TextView
+            android:id="@+id/listing_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/listings_desc"
+            android:fontFamily="sans-serif"
+            android:text="@string/listings_desc"
+            android:textAlignment="viewStart"
+            android:textSize="16sp" />
+    </androidx.cardview.widget.CardView>
+
+    <TextView
+        android:id="@+id/listing_date"
+        android:layout_width="171dp"
+        android:layout_height="26dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/listingDate"
+        android:fontFamily="sans-serif"
+        android:text="@string/listingDate"
+        android:textSize="18sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/move_in_date"
+        app:layout_constraintHorizontal_bias="0.682"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.954" />
+
+    <TextView
+        android:id="@+id/move_in_date"
+        android:layout_width="171dp"
+        android:layout_height="26dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/move_in_date"
+        android:fontFamily="sans-serif"
+        android:text="@string/move_in_date"
+        android:textSize="18sp"
+        android:gravity="end"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.883"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.954" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/activity_view_listing.xml
+++ b/frontend/app/src/main/res/layout/activity_view_listing.xml
@@ -29,8 +29,8 @@
 
     <TextView
         android:id="@+id/housing_type"
-        android:layout_width="180dp"
-        android:layout_height="35dp"
+        android:layout_width="179dp"
+        android:layout_height="28dp"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:contentDescription="@string/housing_type"
@@ -39,14 +39,14 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.121"
+        app:layout_constraintHorizontal_bias="0.145"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
         app:layout_constraintVertical_bias="0.078" />
 
     <TextView
         android:id="@+id/pet_friendly"
-        android:layout_width="180dp"
+        android:layout_width="150dp"
         android:layout_height="35dp"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
@@ -57,36 +57,36 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.93"
+        app:layout_constraintHorizontal_bias="0.798"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
         app:layout_constraintVertical_bias="0.078" />
 
     <TextView
         android:id="@+id/listing_name"
-        android:layout_width="304dp"
-        android:layout_height="35dp"
+        android:layout_width="250dp"
+        android:layout_height="34dp"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:contentDescription="@string/listing_name_desc"
         android:fontFamily="sans-serif"
         android:text="@string/listing_name"
-        android:textSize="28sp"
+        android:textSize="24sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.261"
+        app:layout_constraintHorizontal_bias="0.186"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
-        app:layout_constraintVertical_bias="0.136" />
+        app:layout_constraintVertical_bias="0.199" />
 
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
-        android:layout_width="355dp"
-        android:layout_height="201dp"
+        android:layout_width="329dp"
+        android:layout_height="187dp"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         app:cardBackgroundColor="#FFFFFF"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/listing_date"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.495"
         app:layout_constraintStart_toStartOf="parent"
@@ -102,7 +102,10 @@
             android:text="@string/listings_desc"
             android:textAlignment="viewStart"
             android:textSize="16sp" />
+
     </androidx.cardview.widget.CardView>
+
+    <!-- Edit Buttons for Owners -->
 
     <TextView
         android:id="@+id/listing_date"
@@ -116,27 +119,129 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/move_in_date"
-        app:layout_constraintHorizontal_bias="0.682"
+        app:layout_constraintHorizontal_bias="0.166"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
-        app:layout_constraintVertical_bias="0.954" />
+        app:layout_constraintVertical_bias="0.886" />
 
     <TextView
         android:id="@+id/move_in_date"
-        android:layout_width="171dp"
+        android:layout_width="200dp"
         android:layout_height="26dp"
         android:layout_alignParentBottom="true"
         android:layout_centerHorizontal="true"
         android:contentDescription="@string/move_in_date"
         android:fontFamily="sans-serif"
+        android:gravity="end"
         android:text="@string/move_in_date"
         android:textSize="18sp"
-        android:gravity="end"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.883"
+        app:layout_constraintHorizontal_bias="0.932"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
-        app:layout_constraintVertical_bias="0.954" />
+        app:layout_constraintVertical_bias="0.886" />
+
+    <Button
+        android:id="@+id/edit_title"
+        android:layout_width="50dp"
+        android:layout_height="43dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:background="@android:color/transparent"
+        android:scaleX="1"
+        android:scaleY="1"
+        android:textColor="#D2E2E0"
+        app:icon="@drawable/ic_edit"
+        app:iconTint="#F44336"
+        app:layout_constraintBottom_toTopOf="@+id/edit_housing_desc"
+        app:layout_constraintEnd_toStartOf="@+id/listing_name"
+        app:layout_constraintHorizontal_bias="0.75"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/edit_housing_type"
+        app:layout_constraintVertical_bias="0.555" />
+
+    <Button
+        android:id="@+id/edit_housing_desc"
+        android:layout_width="50dp"
+        android:layout_height="43dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginEnd="4dp"
+        android:background="@android:color/transparent"
+        android:scaleX="1"
+        android:scaleY="1"
+        android:textColor="#D2E2E0"
+        app:icon="@drawable/ic_edit"
+        app:iconTint="#F44336"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/cardView"
+        app:layout_constraintHorizontal_bias="0.551"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/edit_housing_type"
+        app:layout_constraintVertical_bias="0.15" />
+
+    <Button
+        android:id="@+id/edit_housing_type"
+        android:layout_width="50dp"
+        android:layout_height="43dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:layout_marginTop="16dp"
+        android:background="@android:color/transparent"
+        android:scaleX="1"
+        android:scaleY="1"
+        android:textColor="#D2E2E0"
+        app:icon="@drawable/ic_edit"
+        app:iconTint="#F44336"
+        app:layout_constraintBottom_toTopOf="@+id/cardView"
+        app:layout_constraintEnd_toStartOf="@+id/housing_type"
+        app:layout_constraintHorizontal_bias="1.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.107" />
+
+    <Button
+        android:id="@+id/edit_pet_friendly"
+        android:layout_width="40dp"
+        android:layout_height="43dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:background="@android:color/transparent"
+        android:scaleX="1"
+        android:scaleY="1"
+        android:textColor="#D2E2E0"
+        app:icon="@drawable/ic_edit"
+        app:iconTint="#F44336"
+        app:layout_constraintBottom_toTopOf="@+id/edit_move_in_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.75"
+        app:layout_constraintStart_toStartOf="@+id/pet_friendly"
+        app:layout_constraintTop_toBottomOf="@+id/relativeLayout"
+        app:layout_constraintVertical_bias="0.128" />
+
+    <Button
+        android:id="@+id/edit_move_in_button"
+        android:layout_width="60dp"
+        android:layout_height="30dp"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentEnd="true"
+        android:layout_alignParentBottom="true"
+        android:background="@android:color/transparent"
+        android:scaleX="1"
+        android:scaleY="1"
+        android:textColor="#D2E2E0"
+        app:icon="@drawable/ic_edit"
+        app:iconTint="#F44336"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/move_in_date"
+        app:layout_constraintHorizontal_bias="1.2"
+        app:layout_constraintStart_toStartOf="@+id/move_in_date"
+        app:layout_constraintTop_toTopOf="@+id/move_in_date"
+        app:layout_constraintVertical_bias="0.5" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/layout/listings_layout.xml
+++ b/frontend/app/src/main/res/layout/listings_layout.xml
@@ -2,6 +2,7 @@
 <androidx.cardview.widget.CardView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/listingCard"
     android:layout_width="match_parent"
     android:layout_height="120dp"
     android:layout_gravity="center"

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -23,11 +23,28 @@
     <string name="listings_image">placeholder</string>
     <string name="listings_title">placeholder</string>
 
+    <!-- View Listings Activity -->
+    <string name="listings_desc">Listing Desc</string>
+    <string name="listings_desc_text">This is the listing description.</string>
+    <string name="listingDate">Listed Date</string>
+    <string name="move_in_date">Move-in Date</string>
+    <string name="listing_id">ID</string>
+    <string name="pet_friendly">Pet Friendly</string>
+    <string name="posted">Posted:</string>
+    <string name="move">Move-In:</string>
+    <string name="pets">Pets:</string>
+    <string name="allowed">Allowed</string>
+    <string name="not_allowed">Not Allowed</string>
+    <string name="datetime_regex">T</string>
 
     <!-- Content Descriptions -->
     <string name="home_screen_logo">App Logo</string>
     <string name="profile_name">Test Person</string>
     <string name="profile_name_desc">Profile Name</string>
     <string name="profile_image_desc">Profile Picture</string>
+    <string name="listing_name">Test Listing</string>
+    <string name="listing_name_desc">Listing Title</string>
+    <string name="listing_image_desc">Listing Picture</string>
+    <string name="housing_type">Housing Type</string>
 
 </resources>


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #52

## Description of the change:
Added a new activity to view individual listings. Individual listings can be accessed by clicking on them from the listings fragment. Includes: ViewListingsActivity, ListingsItemSelectListener, and modifications to ListingsFragment, ListingsRecyclerData, ListingsRecyclerViewAdapter

## How to manually test:
1. Start up MongoDB
2. Run `npm run dev`
3. Go to Postman and run `POST Create New User`
4. Take the outputted `_id` and run `POST Create Listing under User (With Image)` with the id as `userId`
5. Repeat step 4 as many times as you'd like
6. Take `_id` and paste it into `ListingsFragment` near the end of `onCreateView`. The userId is hardcoded at the moment. 
![image](https://github.com/FarihaIS/VanRoomies/assets/64711237/31f4b7b6-f103-42cb-b123-f865bf01d9ca)
7. Build and run the app
8. Click a listing from the listings menu

**Known Issue:** Images that are too large will cause issues since the base 64 encoded string will be too long for toString() to handle. 8x8 will be our maximum size for now. Also, having more than 9 listings with 8x8 images will also crash the app.