### PR TITLE
feat(recommendations): Backend recommendations

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,12 +6,12 @@ const fs = require('fs');
 const path = require('path');
 
 // Configure environment variable path
-require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}` })
+require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}` });
 
 const app = express();
 const credentials = {
-	key: fs.readFileSync(path.resolve(process.env.KEY_PATH)),
-	cert: fs.readFileSync(path.resolve(process.env.CERT_PATH)),
+    key: fs.readFileSync(path.resolve(process.env.KEY_PATH)),
+    cert: fs.readFileSync(path.resolve(process.env.CERT_PATH)),
 };
 
 const httpsServer = https.createServer(credentials, app);

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -140,7 +140,7 @@ router.get('/:userId/recommendations/listings', async (req, res, next) => {
         } else {
             let error = 'No matching listings available!';
             res.status(404).json({ error: error });
-            next(error);
+            next(new Error(error));
         }
     } catch (error) {
         res.status(400).json({ error: error.message });

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -81,19 +81,14 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
         const tentativeMatchPreferences = await Preferences.find({ userId: { $ne: req.params.userId } }).lean();
 
         let scores = generateUserScores(userPreferences, tentativeMatchPreferences);
-        console.log(scores);
-        let recommendations = generateRecommendations(scores);
-        console.log(recommendations);
 
-        // Not sure this is working well to sort users....
-        const matches = await User.find({ _id: { $in: recommendations } }).lean();
-        const sortedMatches = matches.sort((a, b) => {
-            return recommendations.indexOf(b._id) - recommendations.indexOf(a._id);
-        });
-
-        console.log(sortedMatches);
-
-        res.send('I will give you recommendations for best roommates');
+        // TODO: This needs serious optimization for further milestones - too transactionally-heavy
+        let rankedUsers = [];
+        for (const id of generateRecommendations(scores)) {
+            const currUser = await User.findById(id).lean();
+            rankedUsers.push(currUser);
+        }
+        res.status(200).json(rankedUsers);
     } catch (error) {
         res.status(400).json({ error: error.message });
         next(error);
@@ -110,7 +105,12 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
  */
 router.get('/:userId/recommendations/listings', async (req, res, next) => {
     // TODO: Implement recommendation algorithm here
-    res.send('I will give you recommendations for best fit housing options');
+    try {
+        res.send('I will give you recommendations for best fit housing options');
+    } catch (error) {
+        res.status(400).json({ error: error.message });
+        next(error);
+    }
 });
 
 module.exports = router;

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -1,0 +1,13 @@
+// House Type related constants
+const NONSHAREABLE = ['studio', '1-bedroom'];
+const TWOBEDROOM = '2-bedroom';
+
+// Limit related constants
+const POSINF = Number.POSITIVE_INFINITY;
+const NEGINF = Number.NEGATIVE_INFINITY;
+
+// Habits and enum related constants
+const HABITS = ['smoking', 'partying', 'drinking', 'noise'];
+const NEUTRAL = 'neutral';
+
+module.exports = { NONSHAREABLE, TWOBEDROOM, POSINF, NEGINF, HABITS, NEUTRAL };

--- a/backend/src/utils/listingRecommendations.js
+++ b/backend/src/utils/listingRecommendations.js
@@ -1,9 +1,111 @@
+const { NONSHAREABLE, POSINF, NEGINF } = require('./constants');
+
 /**
- * Rank a set of users based on their corresponding aggregate score.
+ * Rank a set of listings based on their corresponding aggregate score.
  *
  * @param {Array<Array<Object>>} userScores - (userId, score) pair
+ * @returns {Array<ObjectID>} - listing IDs ranked based on their score
  */
-const generateRecommendations = (listingScores) => {
+const generateListingRecommendations = (listingScores) => {
     const listingRanking = listingScores.sort((listing1, listing2) => listing2[1] - listing1[1]);
     return listingRanking.map((listing) => listing[0]);
 };
+
+/**
+ * Calculate compatibility score for each possible listing with the current user
+ *
+ * @param {User Object} userPreferences - preferences of current user seeking housing
+ * @param {User Object} listings - collection of possible listings that could be a match
+ * @returns {Array<Object>} - list of listing id and score pairs
+ */
+const generateListingScores = (userPreferences, listings) => {
+    let listingScores = [];
+
+    const [closestListing, farthestListing] = getClosestFarthestMoveDates(userPreferences, listings);
+
+    listings.forEach((listing) => {
+        let listingScore = 0;
+
+        // Need to perform score calculation based on: [housingType, rentalPrice, petFriendly, moveInDate]
+        const metrics = [calculateHousingTypeScore, calculatePetFriendliness, calculatePriceScore];
+
+        metrics.forEach((metric) => {
+            listingScore += metric(userPreferences, listing);
+        });
+
+        listingScore += calculateMoveInDateScore(listing, closestListing, farthestListing);
+
+        listingScores.push([listing._id, listingScore]);
+    });
+
+    return listingScores;
+};
+
+/**
+ * Compute match score for type of housing between user preferences and given listing
+ *
+ * @param {Object} userPreferences - preferences of current user seeking roommates
+ * @param {Object} listing - potential listing match
+ * @returns {Number} - matching score normalized between 0 and 1
+ */
+const calculateHousingTypeScore = (userPreferences, listing) => {
+    if (userPreferences.housingType === listing.housingType) {
+        return 1;
+    } else if (userPreferences.housingType in NONSHAREABLE && listing.housingType in NONSHAREABLE) {
+        return 0.5;
+    }
+    return 0;
+};
+
+/**
+ * Compute match score for type of pet friendliness between user preferences and given listing
+ *
+ * @param {Object} userPreferences - preferences of current user seeking roommates
+ * @param {Object} listing - potential listing match
+ * @returns {Number} - matching score normalized between 0 and 1
+ */
+const calculatePetFriendliness = (userPreferences, listing) => {
+    return userPreferences.petFriendly === listing.petFriendly;
+};
+
+/**
+ * Compute match score for user price range and listing rental price. This max-min normalizes
+ * the listing price on the given user range and rewards disproportionately so that prices
+ * close to minPrice are awarded closer to a perfect score of 1.
+ *
+ * @param {Object} userPreferences - preferences of current user seeking roommates
+ * @param {Object} listing - potential listing match
+ * @returns {Number} - matching score normalized between 0 and 1
+ */
+const calculatePriceScore = (userPreferences, listing) => {
+    if (listing.rentalPrice > userPreferences.maxPrice || listing.rentalPrice < userPreferences.minPrice) {
+        return 0;
+    }
+    return 1 - (listing.rentalPrice - userPreferences.minPrice) / (userPreferences.maxPrice - userPreferences.minPrice);
+};
+
+const calculateMoveInDateScore = (listing, closestListing, farthestListing) => {
+    const normalizedTimeWindow = (listing.moveInDate - closestListing) / (farthestListing - closestListing);
+    return 1 - normalizedTimeWindow;
+};
+
+const getClosestFarthestMoveDates = (userPreferences, listings) => {
+    let minimalWindow = POSINF,
+        maximalWindow = NEGINF;
+    let closestListing;
+    let farthestListing;
+    listings.forEach((listing) => {
+        let timeDifference = Math.abs(userPreferences.moveInDate - listing.moveInDate);
+        if (timeDifference > maximalWindow) {
+            maximalWindow = timeDifference;
+            farthestListing = listing.moveInDate;
+        }
+        if (timeDifference <= minimalWindow) {
+            minimalWindow = timeDifference;
+            closestListing = listing.moveInDate;
+        }
+    });
+    return [closestListing, farthestListing];
+};
+
+module.exports = { generateListingRecommendations, generateListingScores };

--- a/backend/src/utils/listingRecommendations.js
+++ b/backend/src/utils/listingRecommendations.js
@@ -1,0 +1,9 @@
+/**
+ * Rank a set of users based on their corresponding aggregate score.
+ *
+ * @param {Array<Array<Object>>} userScores - (userId, score) pair
+ */
+const generateRecommendations = (listingScores) => {
+    const listingRanking = listingScores.sort((listing1, listing2) => listing2[1] - listing1[1]);
+    return listingRanking.map((listing) => listing[0]);
+};

--- a/backend/src/utils/listingRecommendations.js
+++ b/backend/src/utils/listingRecommendations.js
@@ -1,15 +1,5 @@
 const { NONSHAREABLE, POSINF, NEGINF } = require('./constants');
-
-/**
- * Rank a set of listings based on their corresponding aggregate score.
- *
- * @param {Array<Array<Object>>} userScores - (userId, score) pair
- * @returns {Array<ObjectID>} - listing IDs ranked based on their score
- */
-const generateListingRecommendations = (listingScores) => {
-    const listingRanking = listingScores.sort((listing1, listing2) => listing2[1] - listing1[1]);
-    return listingRanking.map((listing) => listing[0]);
-};
+const { calculatePetFriendlinessScore } = require('./utils');
 
 /**
  * Calculate compatibility score for each possible listing with the current user
@@ -27,7 +17,7 @@ const generateListingScores = (userPreferences, listings) => {
         let listingScore = 0;
 
         // Need to perform score calculation based on: [housingType, rentalPrice, petFriendly, moveInDate]
-        const metrics = [calculateHousingTypeScore, calculatePetFriendliness, calculatePriceScore];
+        const metrics = [calculateHousingTypeScore, calculatePetFriendlinessScore, calculatePriceScore];
 
         metrics.forEach((metric) => {
             listingScore += metric(userPreferences, listing);
@@ -55,17 +45,6 @@ const calculateHousingTypeScore = (userPreferences, listing) => {
         return 0.5;
     }
     return 0;
-};
-
-/**
- * Compute match score for type of pet friendliness between user preferences and given listing
- *
- * @param {Object} userPreferences - preferences of current user seeking roommates
- * @param {Object} listing - potential listing match
- * @returns {Number} - matching score normalized between 0 and 1
- */
-const calculatePetFriendliness = (userPreferences, listing) => {
-    return userPreferences.petFriendly === listing.petFriendly;
 };
 
 /**
@@ -108,4 +87,4 @@ const getClosestFarthestMoveDates = (userPreferences, listings) => {
     return [closestListing, farthestListing];
 };
 
-module.exports = { generateListingRecommendations, generateListingScores };
+module.exports = { generateListingScores };

--- a/backend/src/utils/userRecommendations.js
+++ b/backend/src/utils/userRecommendations.js
@@ -1,0 +1,126 @@
+/**
+ * Rank a set of users based on their corresponding aggregate score.
+ *
+ * @param {Array<Array<Object>>} userScores - [userId, score] pair
+ */
+const generateRecommendations = (userScores) => {
+    const userRanking = userScores.sort((user1, user2) => user2[1] - user1[1]);
+    return userRanking.map((user) => user[0]);
+};
+
+/**
+ * Calculate compatibility score for each possible match with the current user
+ *
+ * @param {User Object} currentUserPreferences - preferences of current user seeking roommates
+ * @param {User Object} potentialMatchesPreferences - preferences of potential roommates
+ */
+const generateUserScores = (currentUserPreferences, potentialMatchesPreferences) => {
+    let userScores = [];
+    potentialMatchesPreferences.forEach((matchPreferences) => {
+        let currentMatchScore = 0;
+
+        const metrics = [aggregateCategorialPreferenceScores, petFriendlinessScore, housingTypeScore];
+
+        metrics.forEach((metric) => {
+            currentMatchScore += metric(currentUserPreferences, matchPreferences);
+        });
+
+        userScores.push([matchPreferences.userId, currentMatchScore]);
+    });
+    return userScores;
+};
+
+/**
+ * This helper will aggrerate scores for the following preferences of a user:
+ * [smoking, partying, drinking, noise]
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const aggregateCategorialPreferenceScores = (currentUser, possibleMatch) => {
+    let score = 0;
+
+    const categories = ['smoking', 'partying', 'drinking', 'noise'];
+    categories.forEach((preference) => {
+        if (currentUser[preference] === possibleMatch[preference]) {
+            score += 1;
+        } else if (currentUser[preference] === 'neutral' || possibleMatch[preference] === 'neutral') {
+            score += 0.5;
+        } else {
+            score += 0;
+        }
+    });
+
+    return score;
+};
+
+/**
+ * This helper will aggregrate whether the users have the same pet preferences or not
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const petFriendlinessScore = (currentUser, possibleMatch) => {
+    return currentUser.petFriendly === possibleMatch.petFriendly;
+};
+
+/**
+ * This helper will aggregrate whether the users based on the housing type they seek:
+ * ['studio', '1-bedroom', '2-bedroom', 'other']
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const housingTypeScore = (currentUser, possibleMatch) => {
+    const nonShareable = ['studio', '1-bedroom'];
+    if (currentUser.housingType in nonShareable || possibleMatch.housingType in nonShareable) {
+        return 0;
+    } else if (currentUser.housingType === '2-bedroom' && possibleMatch.housingType === '2-bedroom') {
+        return 1;
+    } else {
+        return 0.5;
+    }
+};
+
+/**
+ * This helper scores users based on how much overlap there is in their desired roommate count
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const roommateCountScore = (currentUser, possibleMatch) => {
+    // This needs max-min normalization across all differences
+    const headcountDiff = Math.abs(currentUser.roommateCount - possibleMatch.roommateCount);
+};
+
+/**
+ * This helper scores users based on how much overlap there is in their desired lease lengths
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const leaseLengthScore = (currentUser, possibleMatch) => {
+    // This needs max-min normalization across all differences
+    const leaseLengthDiff = Math.abs(currentUser.leaseLength - possibleMatch.leaseLength);
+};
+
+/**
+ * This helper scores users based on how much overlap there is in their price ranges
+ *
+ * @param {User Object} currentUser - preferences of current user seeking roommates
+ * @param {User Object} possibleMatch - preferences of potential roommates
+ * @returns {Number} - matching score
+ */
+const priceRangeScore = (currentUser, possibleMatch) => {
+    // This needs max-min normalization across all differences
+    let overlapPriceRange =
+        Math.min(currentUser.maxPrice, possibleMatch.maxPrice) - Math.max(currentUser.minPrice, possibleMatch.minPrice);
+    overlapPriceRange = overlapPriceRange >= 0 ? overlapPriceRange : 0;
+};
+
+module.exports = { generateUserScores, generateRecommendations };

--- a/backend/src/utils/userRecommendations.js
+++ b/backend/src/utils/userRecommendations.js
@@ -1,4 +1,4 @@
-const { NONSHAREABLE, TWOBEDROOM, POSINF, NEGINF } = require('./constants');
+const { NONSHAREABLE, TWOBEDROOM, HABITS, NEUTRAL, POSINF, NEGINF } = require('./constants');
 
 /**
  * Rank a set of users based on their corresponding aggregate score.
@@ -51,11 +51,10 @@ const generateUserScores = (currentUserPreferences, potentialMatchesPreferences)
 const aggregateCategorialPreferenceScores = (currentUser, possibleMatch) => {
     let score = 0;
 
-    const categories = ['smoking', 'partying', 'drinking', 'noise'];
-    categories.forEach((preference) => {
+    HABITS.forEach((preference) => {
         if (currentUser[preference] === possibleMatch[preference]) {
             score += 1;
-        } else if (currentUser[preference] === 'neutral' || possibleMatch[preference] === 'neutral') {
+        } else if (currentUser[preference] === NEUTRAL || possibleMatch[preference] === NEUTRAL) {
             score += 0.5;
         }
     });

--- a/backend/src/utils/userRecommendations.js
+++ b/backend/src/utils/userRecommendations.js
@@ -1,15 +1,5 @@
 const { NONSHAREABLE, TWOBEDROOM, HABITS, NEUTRAL, POSINF, NEGINF } = require('./constants');
-
-/**
- * Rank a set of users based on their corresponding aggregate score.
- *
- * @param {Array<Array<Object>>} userScores - [userId, score] pair
- * @returns {Array<ObjectID>} - user IDs ranked based on their score
- */
-const generateUserRecommendations = (userScores) => {
-    const userRanking = userScores.sort((user1, user2) => user2[1] - user1[1]);
-    return userRanking.map((user) => user[0]);
-};
+const { calculatePetFriendlinessScore } = require('./utils');
 
 /**
  * Calculate compatibility score for each possible match with the current user
@@ -24,7 +14,11 @@ const generateUserScores = (currentUserPreferences, potentialMatchesPreferences)
     potentialMatchesPreferences.forEach((matchPreferences) => {
         let currentMatchScore = 0;
 
-        const categoricalMetrics = [aggregateCategorialPreferenceScores, petFriendlinessScore, housingTypeScore];
+        const categoricalMetrics = [
+            aggregateCategorialPreferenceScores,
+            calculatePetFriendlinessScore,
+            housingTypeScore,
+        ];
         const numericalMetrics = [roommateCountScore, leaseLengthScore, priceRangeScore];
 
         categoricalMetrics.forEach((metric) => {
@@ -60,17 +54,6 @@ const aggregateCategorialPreferenceScores = (currentUser, possibleMatch) => {
     });
 
     return score;
-};
-
-/**
- * This helper will aggregrate whether the users have the same pet preferences or not
- *
- * @param {User Object} currentUser - preferences of current user seeking roommates
- * @param {User Object} possibleMatch - preferences of potential roommates
- * @returns {Number} - matching score
- */
-const petFriendlinessScore = (currentUser, possibleMatch) => {
-    return currentUser.petFriendly === possibleMatch.petFriendly;
 };
 
 /**
@@ -210,4 +193,4 @@ const calculateMinMaxRanges = (currentUser, potentialMatches) => {
     };
 };
 
-module.exports = { generateUserRecommendations, generateUserScores };
+module.exports = { generateUserScores };

--- a/backend/src/utils/userRecommendations.js
+++ b/backend/src/utils/userRecommendations.js
@@ -1,9 +1,12 @@
+const { NONSHAREABLE, TWOBEDROOM, POSINF, NEGINF } = require('./constants');
+
 /**
  * Rank a set of users based on their corresponding aggregate score.
  *
  * @param {Array<Array<Object>>} userScores - [userId, score] pair
+ * @returns {Array<ObjectID>} - user IDs ranked based on their score
  */
-const generateRecommendations = (userScores) => {
+const generateUserRecommendations = (userScores) => {
     const userRanking = userScores.sort((user1, user2) => user2[1] - user1[1]);
     return userRanking.map((user) => user[0]);
 };
@@ -13,6 +16,7 @@ const generateRecommendations = (userScores) => {
  *
  * @param {User Object} currentUserPreferences - preferences of current user seeking roommates
  * @param {User Object} potentialMatchesPreferences - preferences of potential roommates
+ * @returns {Array<Object>} - list of user id and score pairs
  */
 const generateUserScores = (currentUserPreferences, potentialMatchesPreferences) => {
     let userScores = [];
@@ -71,7 +75,7 @@ const petFriendlinessScore = (currentUser, possibleMatch) => {
 };
 
 /**
- * This helper will aggregrate whether the users based on the housing type they seek:
+ * This helper will aggregrate scores based on the type of housing the user prefers:
  * ['studio', '1-bedroom', '2-bedroom', 'other']
  *
  * @param {User Object} currentUser - preferences of current user seeking roommates
@@ -79,10 +83,9 @@ const petFriendlinessScore = (currentUser, possibleMatch) => {
  * @returns {Number} - matching score
  */
 const housingTypeScore = (currentUser, possibleMatch) => {
-    const nonShareable = ['studio', '1-bedroom'];
-    if (currentUser.housingType in nonShareable || possibleMatch.housingType in nonShareable) {
+    if (currentUser.housingType in NONSHAREABLE || possibleMatch.housingType in NONSHAREABLE) {
         return 0;
-    } else if (currentUser.housingType === '2-bedroom' && possibleMatch.housingType === '2-bedroom') {
+    } else if (currentUser.housingType === TWOBEDROOM && possibleMatch.housingType === TWOBEDROOM) {
         return 1;
     } else {
         return 0.5;
@@ -90,7 +93,7 @@ const housingTypeScore = (currentUser, possibleMatch) => {
 };
 
 /**
- * This helper scores users based on how much overlap there is in their desired roommate count
+ * This helper scores users based on how close the desired roommate count is
  *
  * @param {User Object} currentUser - preferences of current user seeking roommates
  * @param {User Object} possibleMatch - preferences of potential roommates
@@ -108,7 +111,7 @@ const roommateCountScore = (currentUser, possibleMatch, minMaxRanges) => {
 };
 
 /**
- * This helper scores users based on how much overlap there is in their desired lease lengths
+ * This helper scores users based on how similar the desired lease lengths are
  *
  * @param {User Object} currentUser - preferences of current user seeking roommates
  * @param {User Object} possibleMatch - preferences of potential roommates
@@ -126,7 +129,9 @@ const leaseLengthScore = (currentUser, possibleMatch, minMaxRanges) => {
 };
 
 /**
- * This helper scores users based on how much overlap there is in their price ranges
+ * This helper scores users based on how much overlap there is in their price ranges.
+ * It aims to rewards better for higher overlaps as it means users are more likely
+ * to reach on a roommate agreement based on this.
  *
  * @param {User Object} currentUser - preferences of current user seeking roommates
  * @param {User Object} possibleMatch - preferences of potential roommates
@@ -158,12 +163,12 @@ const priceRangeScore = (currentUser, possibleMatch, minMaxRanges) => {
  * @param {User Object} potentialMatchesPreferences - preferences of potential roommates
  */
 const calculateMinMaxRanges = (currentUser, potentialMatches) => {
-    let minRoomMateCountRange = Number.POSITIVE_INFINITY,
-        maxRoomMateCountRange = Number.NEGATIVE_INFINITY;
-    let minLeaseLengthRange = Number.POSITIVE_INFINITY,
-        maxLeaseLengthRange = Number.NEGATIVE_INFINITY;
-    let minPriceOverlapRange = Number.POSITIVE_INFINITY,
-        maxPriceOverlapRange = Number.NEGATIVE_INFINITY;
+    let minRoomMateCountRange = POSINF,
+        maxRoomMateCountRange = NEGINF;
+    let minLeaseLengthRange = POSINF,
+        maxLeaseLengthRange = NEGINF;
+    let minPriceOverlapRange = POSINF,
+        maxPriceOverlapRange = NEGINF;
 
     potentialMatches.forEach((potentialMatch) => {
         // Roommate Count Range
@@ -206,4 +211,4 @@ const calculateMinMaxRanges = (currentUser, potentialMatches) => {
     };
 };
 
-module.exports = { generateUserScores, generateRecommendations };
+module.exports = { generateUserRecommendations, generateUserScores };

--- a/backend/src/utils/utils.js
+++ b/backend/src/utils/utils.js
@@ -1,0 +1,25 @@
+/**
+ * Rank a set of IDs based on their corresponding aggregate score.
+ * Generalized for both user scoring and listing scoring.
+ *
+ * @param {Array<Array<Object>>} scoreIdPair - (ID, score) pair
+ * @returns {Array<ObjectID>} - IDs ranked based on their score
+ */
+const generateRecommendations = (scoreIdPair) => {
+    const rankedPairs = scoreIdPair.sort((item1, item2) => item2[1] - item1[1]);
+    return rankedPairs.map((pair) => pair[0]);
+};
+
+/**
+ * This helper will aggregrate scores based on pet preferences for a user against
+ * another entity from the database collection
+ *
+ * @param {User Object} user - preferences of user
+ * @param {User Object} other - otherEntity
+ * @returns {Number} - matching score
+ */
+const calculatePetFriendlinessScore = (user, other) => {
+    return user.petFriendly === other.petFriendly ? 1 : 0;
+};
+
+module.exports = { generateRecommendations, calculatePetFriendlinessScore };


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #34 

## Description of the change:
This PR aims to introduce our score-based recommendations for users and listings. It introduces the following two endpoints:

- `GET localhost:3000/api/users/:userId/recommendations/users`
- `GET localhost:3000/api/users/:userId/recommendations/listings`

The reommendations are done on the basis of preference matching as well as via max-min normalization so that each preference contributes a maximum of 1 point to the score of that record. 

## How to manually test:
1. *Run `npm run dev`*
2. Create a few test users, corresponding preferences for them. Add a few listings under the ID of some of the users. For now you can use the Postman collection that does not mandate authentication. It is just important to be able to populate the database a bit. If needed, reach out to myself (@dlalaj) for a copy of my MongoDB collections that you can use for testing.
3. Post a `GET` in each of the two routes above via a userID. Note that the userID should not be for a user who has created listings. You can browse the results in the response to get an idea of how the matches are sorted based on best-overall fit.
