### PR TITLE
feat(create listing): Add a Listing Creation Button to Owned Listings

### DIFF
--- a/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
@@ -6,7 +6,7 @@ public class Constants {
     // final static String baseServerURL = "Insert VM Server URL";
     final static String helloWorldEndpoint = "/"; // GET
     final static String listingByUserIdEndpoint = "/api/listings/user/"; // GET, needs user_id appended
-    final static String listingByListingIdEndpoint = "/api/listings/"; // GET/PUT, needs listing_id appended
+    final static String listingByListingIdEndpoint = "/api/listings/"; // GET/PUT, needs listing_id appended. POST does not.
     final static String userEndpoint = "/api/users/"; // GET/PUT/DELETE needs user_id appended. POST does not.
     public static String chatsByUserIdEndpoint = "/api/chat/conversations/user/";
 

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.CompoundButton;
 import android.widget.TextView;
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -39,6 +40,7 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
     // TODO: Maintain user_id within the app and use it as an input here
     String userId = "65402f35e10ec75253936947";
     public SwitchMaterial toggleButton;
+    public Button addListingButton;
     public TextView titleText;
     final static Gson g = new Gson();
     final static int view_cols = 2;
@@ -98,15 +100,25 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
         // Setting up Toggle Button
         toggleButton = view.findViewById(R.id.listings_toggle);
         toggleButton.setText("");
+
+        // Setting up Create Listing Button
+        addListingButton = view.findViewById(R.id.createListingButton);
+        addListingButton.setEnabled(false);
+        addListingButton.setVisibility(View.INVISIBLE);
+
         titleText = (TextView) view.findViewById(R.id.listings_header);
         titleText.setText(getString(R.string.listings_header_recommended));
         toggleButton.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView,boolean isChecked) {
                 if(isChecked){
+                    addListingButton.setEnabled(true);
+                    addListingButton.setVisibility(View.VISIBLE);
                     titleText.setText(getString(R.string.listings_header_owned));
                     getOwnedListings(httpClient, view, getActivity(), userId);
                 } else {
+                    addListingButton.setEnabled(false);
+                    addListingButton.setVisibility(View.INVISIBLE);
                     titleText.setText(getString(R.string.listings_header_recommended));
                     getRecommendedListings(httpClient, view, getActivity(), userId);
                 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ListingsFragment.java
@@ -1,6 +1,10 @@
 package com.chads.vanroomies;
 
 import android.app.Activity;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -11,11 +15,17 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CompoundButton;
+import android.widget.EditText;
+import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.google.gson.Gson;
+
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import java.io.IOException;
@@ -25,8 +35,10 @@ import java.util.List;
 import java.util.Map;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.FormBody;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 
 /**
@@ -95,16 +107,83 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
 
         httpClient = HTTPSClientFactory.createClient(getActivity().getApplication());
         // TODO: Maintain user_id within the app and use it as an input here
-        getRecommendedListings(httpClient, view, getActivity(), "65402f35e10ec75253936947");
+        getRecommendedListings(httpClient, view, getActivity());
 
         // Setting up Toggle Button
         toggleButton = view.findViewById(R.id.listings_toggle);
         toggleButton.setText("");
 
-        // Setting up Create Listing Button
+        // Setting up Add Listing Button
         addListingButton = view.findViewById(R.id.createListingButton);
         addListingButton.setEnabled(false);
         addListingButton.setVisibility(View.INVISIBLE);
+        addListingButton.setOnClickListener(temp -> {
+            // Setting up Add Listing Prompt
+            Context context = view.getContext();
+            AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(context);
+            LinearLayout layout = new LinearLayout(context);
+            layout.setOrientation(LinearLayout.VERTICAL);
+
+            final EditText titleBox = new EditText(context);
+            final EditText descriptionBox = new EditText(context);
+            final EditText housingType = new EditText(context);
+            final EditText rentalPrice = new EditText(context);
+            // final EditText moveInDate = new EditText(context);
+            final EditText petFriendly = new EditText(context);
+
+            titleBox.setHint("Listing Title (5 characters minimum)");
+            descriptionBox.setHint("Description");
+            housingType.setHint("Housing Type (Must be: 'studio', '1-bedroom', '2-bedroom', or 'other')");
+            rentalPrice.setHint("Rental Price (Numerical)");
+            petFriendly.setHint("Pets Allowed? (Y/N)");
+
+            layout.addView(titleBox);
+            layout.addView(housingType);
+            layout.addView(descriptionBox);
+            layout.addView(rentalPrice);
+            layout.addView(petFriendly);
+
+            alertDialogBuilder.setView(layout); // Again this is a set method, not add
+            alertDialogBuilder.setCancelable(true).setPositiveButton("Create", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                    List<String> listingParams = new ArrayList<>();
+                    listingParams.add(titleBox.getText().toString());
+                    listingParams.add(descriptionBox.getText().toString());
+                    listingParams.add(housingType.getText().toString());
+                    listingParams.add(rentalPrice.getText().toString());
+                    listingParams.add(petFriendly.getText().toString());
+                    // Ensuring all fields are filled out
+                    if (listingParams.contains("")) {
+                        Toast.makeText(context, "Please fill in all fields.", Toast.LENGTH_LONG).show();
+                    } else if (listingParams.get(0).length() < 5) {
+                        Toast.makeText(context, "The title must be at least 5 characters long.", Toast.LENGTH_LONG).show();
+                    } else if (!listingParams.get(2).equals("studio") && !listingParams.get(2).equals("1-bedroom")
+                            && !listingParams.get(2).equals("2-bedroom") && !listingParams.get(2).equals("other")) {
+                        Toast.makeText(context, "Housing Type must be one of: 'studio', " +
+                                "'1-bedroom', '2-bedroom', or 'other'", Toast.LENGTH_LONG).show();
+                    } else if (!isNumeric(listingParams.get(3))){
+                        Toast.makeText(context, "The rental price must be numerical (i.e. '1500').", Toast.LENGTH_LONG).show();
+                    } else if (!listingParams.get(4).equals("Y") && !listingParams.get(4).equals("N")) {
+                        Toast.makeText(context, "Pet Friendly must be 'Y' or 'N'", Toast.LENGTH_LONG).show();
+                    } else {
+                        try {
+                            Log.d(TAG, "Creating Listing.");
+                            createListing(httpClient, view, getActivity(), listingParams);
+                        } catch (JSONException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            }).setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    dialog.dismiss();
+                }
+            });
+            AlertDialog alertDialog = alertDialogBuilder.create();
+            alertDialog.show();
+        });
+
 
         titleText = (TextView) view.findViewById(R.id.listings_header);
         titleText.setText(getString(R.string.listings_header_recommended));
@@ -115,22 +194,22 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
                     addListingButton.setEnabled(true);
                     addListingButton.setVisibility(View.VISIBLE);
                     titleText.setText(getString(R.string.listings_header_owned));
-                    getOwnedListings(httpClient, view, getActivity(), userId);
+                    getOwnedListings(httpClient, view, getActivity());
                 } else {
                     addListingButton.setEnabled(false);
                     addListingButton.setVisibility(View.INVISIBLE);
                     titleText.setText(getString(R.string.listings_header_recommended));
-                    getRecommendedListings(httpClient, view, getActivity(), userId);
+                    getRecommendedListings(httpClient, view, getActivity());
                 }
             }
         });
         return view;
     }
-    public void getRecommendedListings(OkHttpClient client, View view, Activity act, String user_id){
-        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByUserIdEndpoint + user_id).build();
+    public void getRecommendedListings(OkHttpClient client, View view, Activity act){
+        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByUserIdEndpoint + userId).build();
         // recommended
-        // Request request = new Request.Builder().url(Constants.BaseServerURL + Constants.listingByRecommendationsEndpoint(user_id)).build();
-        Log.d(String.format("%s: RECOMMENDED", TAG), Constants.baseServerURL + Constants.listingByRecommendationsEndpoint(user_id));
+        // Request request = new Request.Builder().url(Constants.BaseServerURL + Constants.listingByRecommendationsEndpoint(userId)).build();
+        Log.d(String.format("%s: RECOMMENDED", TAG), Constants.baseServerURL + Constants.listingByRecommendationsEndpoint(userId));
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
@@ -149,7 +228,11 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
                             Map<String, Object> listing_json = responseDataList.get(index);
                             JSONObject listing_obj = new JSONObject(listing_json);
                             String listing_title = listing_obj.getString("title");
-                            String listing_photo = listing_obj.getJSONArray("images").get(0).toString();
+                            JSONArray listing_photo_array = listing_obj.getJSONArray("images");
+                            String listing_photo = "";
+                            if (listing_photo_array.length() > 0){
+                                listing_photo = listing_photo_array.get(0).toString();
+                            }
                             // Information taken to individual listing
                             String listing_id = listing_obj.getString("_id");
                             HashMap<String, String> additionalInfo = new HashMap<>();
@@ -182,9 +265,9 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
             }
         });
     }
-    public void getOwnedListings(OkHttpClient client, View view, Activity act, String user_id){
-        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByUserIdEndpoint + user_id).build();
-        Log.d(String.format("%s: OWNED", TAG), Constants.baseServerURL + Constants.listingByUserIdEndpoint + user_id);
+    public void getOwnedListings(OkHttpClient client, View view, Activity act){
+        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByUserIdEndpoint + userId).build();
+        Log.d(String.format("%s: OWNED", TAG), Constants.baseServerURL + Constants.listingByUserIdEndpoint + userId);
         client.newCall(request).enqueue(new Callback() {
             @Override
             public void onFailure(@NonNull Call call, @NonNull IOException e) {
@@ -205,8 +288,11 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
 
                             // Information shown in list
                             String listing_title = listing_obj.getString("title");
-                            String listing_photo = listing_obj.getJSONArray("images").get(0).toString();
-
+                            JSONArray listing_photo_array = listing_obj.getJSONArray("images");
+                            String listing_photo = "";
+                            if (listing_photo_array.length() > 0){
+                                listing_photo = listing_photo_array.get(0).toString();
+                            }
                             // Information taken to individual listing
                             String listing_id = listing_obj.getString("_id");
                             HashMap<String, String> additionalInfo = new HashMap<>();
@@ -251,5 +337,50 @@ public class ListingsFragment extends Fragment implements ListingsItemSelectList
         intent.putExtras(b);
 
         startActivity(intent);
+    }
+
+    public void createListing(OkHttpClient client, View view, Activity act, List<String> params) throws JSONException {
+        String petFriendly;
+        if (params.get(4).equals("Y")){
+            petFriendly = "true";
+        }
+        else {
+            petFriendly = "false";
+        }
+        // Setting up a POST request
+        RequestBody formBody = new FormBody.Builder()
+                .add("userId", userId)
+                .add("title", params.get(0))
+                .add("description", params.get(1))
+                .add("housingType", params.get(2))
+                .add("rentalPrice", params.get(3))
+                .add("listingDate", "2023-10-22") // ToDo: Get current date in future milestones
+                .add("moveInDate", "2024-01-01") // ToDo: Get from user and parse in future milestones
+                .add("petFriendly", petFriendly)
+                .add("status", "active")
+                .build();
+
+        Request request = new Request.Builder().url(Constants.baseServerURL + Constants.listingByListingIdEndpoint)
+                .post(formBody) // POST
+                .build();
+        client.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                Log.d(TAG, e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                act.runOnUiThread(() -> getOwnedListings(client, view, act));
+            }
+        });
+    }
+    public static boolean isNumeric(String input) {
+        try {
+            Double.parseDouble(input);
+            return true;
+        } catch(NumberFormatException e){
+            return false;
+        }
     }
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
@@ -23,6 +23,7 @@ import com.google.gson.Gson;
 import org.json.JSONException;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import okhttp3.Call;
@@ -208,7 +209,11 @@ public class ViewListingActivity extends AppCompatActivity {
 
 
                         // Fetching Parameters
-                        String photo_string = result.getImages().get(0);
+                        String photoString = "";
+                        List<String> imagesList = result.getImages();
+                        if (imagesList.size() > 0){
+                            photoString = imagesList.get(0);
+                        }
                         String title = result.getTitle();
                         String description = result.getDescription();
                         String housingType = result.getHousingType();
@@ -226,7 +231,7 @@ public class ViewListingActivity extends AppCompatActivity {
                         TextView pet_textview = findViewById(R.id.pet_friendly);
 
                         // Setting ImageView
-                        byte[] decodedString = Base64.decode(photo_string, Base64.DEFAULT);
+                        byte[] decodedString = Base64.decode(photoString, Base64.DEFAULT);
                         Bitmap decodedByte = BitmapFactory.decodeByteArray(decodedString, 0, decodedString.length);
                         listing_image.setImageBitmap(decodedByte);
 

--- a/frontend/app/src/main/res/layout/fragment_listings.xml
+++ b/frontend/app/src/main/res/layout/fragment_listings.xml
@@ -13,6 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="560dp"
         android:layout_marginTop="24dp"
+        android:translationY="-35dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/listings_header"
         app:layout_constraintVertical_bias="0.0"
@@ -23,12 +24,13 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/listings_toggle"
-        app:layout_constraintBottom_toTopOf="@+id/idListingsRV"
+        android:translationY="5dp"
+        app:layout_constraintBottom_toTopOf="@+id/listings_header"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1.0"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintHorizontal_bias="0.935"
+        app:layout_constraintStart_toEndOf="@+id/createListingButton"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintVertical_bias="0.761" />
 
     <TextView
         android:id="@+id/listings_header"
@@ -38,12 +40,28 @@
         android:textAlignment="center"
         android:textAllCaps="false"
         android:textSize="24sp"
+        android:translationX="10dp"
+        android:translationY="-40dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/listings_toggle"
-        app:layout_constraintHorizontal_bias="0.497"
+        app:layout_constraintHorizontal_bias="0.495"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.021" />
+        app:layout_constraintVertical_bias="0.098" />
+
+    <Button
+        android:id="@+id/createListingButton"
+        android:layout_width="55dp"
+        android:layout_height="55dp"
+        android:text="@string/add_listing_button_text"
+        android:textAlignment="center"
+        android:translationY="10dp"
+        app:layout_constraintBottom_toTopOf="@+id/listings_header"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.044"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.642" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="allowed">Allowed</string>
     <string name="not_allowed">Not Allowed</string>
     <string name="datetime_regex">T</string>
+    <string name="add_listing_button_text">+</string>
 
     <!-- Content Descriptions -->
     <string name="home_screen_logo">App Logo</string>


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #68 

## Description of the change:
Add a button to the listingsFragment that can only enabled and visible when viewing "Owned" listings. Clicking the button will create a prompt to fill out listing details which are then validated on the frontend and sent in a POST request to create a new listing. The new listing is immediately available in the list.

## How to manually test:
1. Start up MongoDB
2. **On the backend, go to `src\models\listingModel.js` and change line 49 `required: true` to `required: false`. This will be changed in a PR by @dlalaj, but for testing purposes, you'll have to do this manually.**
3. Run `npm run dev` inside the backend folder
4. Build and run the app
5. On the listingsFragment, click the (+) button and fill out the prompt
6. Try this with valid and invalid inputs!
