### PR TITLE
enhancement(preferences): Add User Exclusion Route for Recommendations

### DIFF
--- a/backend/src/models/listingModel.js
+++ b/backend/src/models/listingModel.js
@@ -45,8 +45,7 @@ const ListingSchema = new mongoose.Schema({
         type: {
             latitude: { type: Number, required: true },
             longitude: { type: Number, required: true },
-        },
-        required: true,
+        }
     },
     images: [{ type: String }],
 });

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -51,6 +51,10 @@ const UserSchema = new mongoose.Schema({
     bio: {
         type: String,
     },
+    notRecommended: {
+        type: [{ type: mongoose.Types.ObjectId }],
+        default: [],
+    },
     // password: { type: String, required: true, minength: 8, maxlength: 30 },
 });
 

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -116,7 +116,7 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
  *
  * Route: POST /api/users/:userId/recommendations/users
  *
- * Body: {exludedId: ""}
+ * Body: {excludedId: ""}
  */
 router.put('/:userId/recommendations/users', async (req, res, next) => {
     try {

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -94,7 +94,7 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
             // TODO: This REQUIRES optimization for further milestones - too transactionally-heavy
             let rankedUsers = [];
             for (const id of generateRecommendations(scores)) {
-                const currUser = await User.findById(id).lean();
+                const currUser = await User.findById(id).select('firstName lastName profilePicture bio').lean();
                 rankedUsers.push(currUser);
             }
             res.status(200).json(rankedUsers);

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -86,8 +86,9 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
             res.status(404).json({ error: error });
             next(new Error(error));
         }
-
-        const tentativeMatchPreferences = await Preferences.find({ userId: { $ne: req.params.userId } }).lean();
+        const currUser = await User.findById(req.params.userId);
+        const excluded = [req.params.userId, ...currUser.notRecommended];
+        const tentativeMatchPreferences = await Preferences.find({ userId: { $nin: excluded } }).lean();
         if (tentativeMatchPreferences) {
             let scores = generateUserScores(userPreferences, tentativeMatchPreferences);
 
@@ -102,6 +103,33 @@ router.get('/:userId/recommendations/users', async (req, res, next) => {
             let error = 'No preferences found for given user!';
             res.status(404).json({ error: error });
             next(new Error(error));
+        }
+    } catch (error) {
+        res.status(400).json({ error: error.message });
+        next(error);
+    }
+});
+
+/**
+ * This endpoint pushes a new userId on the list of excluded users that are
+ * not to be recommended for a given user via the recommendation routes
+ *
+ * Route: POST /api/users/:userId/recommendations/users
+ *
+ * Body: {exludedId: ""}
+ */
+router.put('/:userId/recommendations/users', async (req, res, next) => {
+    try {
+        const excludedUser = new mongoose.Types.ObjectId(req.body.excludedId);
+        const updatedUser = await User.updateOne(
+            { _id: req.params.userId },
+            { $push: { notRecommended: excludedUser } },
+            { new: true },
+        );
+        if (updatedUser) {
+            res.status(200).json(updatedUser);
+        } else {
+            res.status(404).json({ error: 'Cannot update, user not found' });
         }
     } catch (error) {
         res.status(400).json({ error: error.message });
@@ -125,7 +153,6 @@ router.get('/:userId/recommendations/listings', async (req, res, next) => {
             res.status(404).json({ error: error });
             next(new Error(error));
         }
-
         const tentativeMatchListings = await Listing.find({ userId: { $ne: req.params.userId } }).lean();
         if (tentativeMatchListings) {
             let scores = generateListingScores(userPreferences, tentativeMatchListings);


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #69 

## Description of the change:
This PR will allow for users to have a collection of user ids that they will not be recommended through the matching system. Ths feature is in place because once a user messages another user, they should not see that user in their list of recommendations again.

Minor fix 1: Change response body of what is sent to the FE for the list of recommendations by removing unused information from User objects.
Minor fix 2: Remove required constraint on Listing as it is not something we use at present.

## How to manually test:
1. Run `npm run dev`
2. You can send a request through this route`PUT api/users/:userId/recommendations/users` with the following format for the request body `{"exludedId": <String - ObjectID>}` where the String is the ID of the user which we are trying to remove from the list of possible matches for the currently logged in user.
3. In subsequent requests of that get recommendations for the logged in user, the excluded user above should no longer show up.
