### PR TITLE
feat(conversations): add inactive status to user in conversation schema, and add a route t…

### DIFF
--- a/backend/src/chat/messageStore.js
+++ b/backend/src/chat/messageStore.js
@@ -5,7 +5,7 @@ class UserRecord {
     // userId: ObjectId, inactive: Boolean
     constructor(userId, inactive) {
         this.userId = userId;
-        this.inactive = inactive ? inactive : false;
+        this.inactive = inactive;
     }
 }
 

--- a/backend/src/models/conversationModel.js
+++ b/backend/src/models/conversationModel.js
@@ -1,0 +1,16 @@
+const { default: mongoose } = require('mongoose');
+
+const conversationSchema = new mongoose.Schema({
+    users: {
+        type: [Object],
+        required: true,
+    },
+    messages: {
+        type: [Object],
+        default: [],
+    },
+});
+
+const Conversation = mongoose.model('Conversation', conversationSchema);
+
+module.exports = Conversation;

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -34,7 +34,7 @@ router.put('/conversations/user/:userId', async (req, res, next) => {
             throw new Error('Conversation not found');
         }
         conversation.users.forEach((user) => {
-            if (user.user == sendingUserId) {
+            if (user.userId == sendingUserId) {
                 user.inactive = req.body.inactive;
             }
         });

--- a/backend/src/routes/chat.js
+++ b/backend/src/routes/chat.js
@@ -3,37 +3,71 @@ const router = express.Router();
 
 const messageStore = require('../chat/messageStore');
 
-router.get('/conversations/:conversationId', async (req, res, next) => {
-    try {
-        const messages = await messageStore.getConversation(req.params.conversationId);
-        res.json(messages);
-        next();
-    } catch (error) {
-        res.status(404).json({ error: error });
-        next(error);
-    }
-});
-
+/**
+ * Get a List of all Conversation objects that a user is involved in.
+ *
+ * Resp: [{conversationId: UserId, users: [UserId], messages: [Message]}]
+ */
 router.get('/conversations/user/:userId', async (req, res, next) => {
     try {
         const conversations = await messageStore.getConversationsByUser(req.params.userId);
         res.json(conversations);
-        next();
     } catch (error) {
-        res.status(404).json({ error: error });
+        res.status(404).json({ error: error.message });
         next(error);
     }
 });
 
+/**
+ * Update the inactive field in the Conversation object.
+ *
+ * Params: Path: {userId: UserId}, Body: {to: UserId, inactive: Boolean}
+ *
+ * Resp: {}
+ */
+router.put('/conversations/user/:userId', async (req, res, next) => {
+    try {
+        const receivingUserId = req.body.to;
+        const sendingUserId = req.params.userId;
+        const conversation = await messageStore.getConversation(sendingUserId, receivingUserId);
+        if (!conversation) {
+            throw new Error('Conversation not found');
+        }
+        conversation.users.forEach((user) => {
+            if (user.user == sendingUserId) {
+                user.inactive = req.body.inactive;
+            }
+        });
+        const newConversation = await conversation.save();
+        res.json(newConversation);
+    } catch (error) {
+        res.status(404).json({ error: error.message });
+        next(error);
+    }
+});
+
+/**
+ * Create a new Conversation from a user to another user.
+ *
+ * Params: Path: {userId: UserId}, Body: {to: UserId}
+ *
+ * Resp: {}
+ */
 router.post('/conversations/user/:userId', async (req, res, next) => {
     try {
         const receivingUserId = req.body.to;
         const sendingUserId = req.params.userId;
+        const existing = await messageStore.getConversation(sendingUserId, receivingUserId);
+        if (existing) {
+            const err = new Error('Conversation already exists');
+            res.status(409).json({ error: err.message });
+            return next(err);
+        }
+
         const conversation = await messageStore.sendMessage(req.body.content, sendingUserId, receivingUserId);
         res.status(201).json(conversation);
-        next();
     } catch (error) {
-        res.status(404).json({ error: error });
+        res.status(404).json({ error: error.message });
         next(error);
     }
 });


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #79 

## Description of the change:
Updates the Conversation schema to replace the inner `users` field from a `UserId` string to an object of the form `UserRecord`. This is of the form:
```js
{
    userId: ObjectId,
    inactive: Boolean
}
```

The new route to update this is at `/api/chat/conversations/user/:userId`.
We need to provide a body paramter `to` with this request, which is the ObjectId of the userId that the conversation is with. The path parameter `userId` is the User which this request will affect. We also need another body parameter `inactive` with the new value: `true` or `false`.

## How to manually test:
1. *Run `npm run dev`*
2. Create a conversation between two users.
3. send a request to the endpoint above with the correct `to` and `inactive` body parameters. (There is an existing request in our Postman collection).
