### PR TITLE
feat(chat): Add Block User Functionality for FE

### DIFF
--- a/frontend/app/src/main/java/com/chads/vanroomies/ChatFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ChatFragment.java
@@ -63,7 +63,7 @@ public class ChatFragment extends Fragment {
     }
 
     private void updateChatFragment(View v) {
-        ChatListAdapter chatListAdapter = new ChatListAdapter(v.getContext(), allChatMessages, thisUserId);
+        ChatListAdapter chatListAdapter = new ChatListAdapter(v.getContext(), allChatMessages, thisUserId, httpClient, getActivity());
         chatListRecycler.setAdapter((chatListAdapter));
     }
 

--- a/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
@@ -1,29 +1,47 @@
 package com.chads.vanroomies;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Base64;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
 import androidx.recyclerview.widget.RecyclerView;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import de.hdodenhof.circleimageview.CircleImageView;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 public class ChatListAdapter extends RecyclerView.Adapter {
+    final static String TAG = "ChatListAdapter";
     private final Context context;
     private final ArrayList<Map.Entry<UserProfile, ArrayList<ChatMessage>>> chats;
     private final String userId;
+    private OkHttpClient httpClient;
+    private FragmentActivity fragmentActivity;
 
-    public ChatListAdapter(Context context, Map<UserProfile, ArrayList<ChatMessage>> chats, String userId) {
+    public ChatListAdapter(Context context, Map<UserProfile, ArrayList<ChatMessage>> chats, String userId, OkHttpClient httpClient, FragmentActivity fragmentActivity) {
         this.context = context;
         this.chats = new ArrayList<>(chats.entrySet());
         this.userId = userId;
+        this.httpClient = httpClient;
+        this.fragmentActivity = fragmentActivity;
     }
 
     @Override
@@ -61,6 +79,8 @@ public class ChatListAdapter extends RecyclerView.Adapter {
         else {
             ((ChatListHolder) holder).imageView.setImageResource(R.drawable.ic_profile);
         }
+        
+        ((ChatListHolder) holder).blockView.setOnClickListener(v -> showBlockUserAlert(entry));
 
         holder.itemView.setOnClickListener(v -> {
             Intent chatChannelIntent = new Intent(context, ChatChannelActivity.class);
@@ -71,14 +91,76 @@ public class ChatListAdapter extends RecyclerView.Adapter {
         });
     }
 
+    private void showBlockUserAlert(Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setMessage("Are you sure you want to block " + entry.getKey().getFirstName() + " " + entry.getKey().getLastName() + " permanently?")
+                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Log.d(TAG, "Sending block user request");
+                        sendBlockUserRequest(httpClient, fragmentActivity, entry);
+                    }
+                })
+                .setNegativeButton("No", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        Log.d(TAG, "Dismissing dialog for block user");
+                        dialog.dismiss();
+                    }
+                });
+
+        AlertDialog alertDialog = builder.create();
+        alertDialog.show();
+    }
+
+    private void sendBlockUserRequest(OkHttpClient httpClient, FragmentActivity fragmentActivity, Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
+        String url = Constants.baseServerURL + Constants.userEndpoint + userId + Constants.blockByUserIdEndpoint;
+        Log.d(TAG, "Block userId " + entry.getKey().get_id());
+        RequestBody requestBody = new FormBody.Builder()
+                .add("blockedId", entry.getKey().get_id())
+                .build();
+        Request request = new Request.Builder()
+                .url(url)
+                .post(requestBody)
+                .build();
+
+        httpClient.newCall(request).enqueue(new Callback() {
+            @Override
+            public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                Log.d(TAG, e.getMessage());
+            }
+
+            @Override
+            public void onResponse(@NonNull Call call, @NonNull Response response) {
+                fragmentActivity.runOnUiThread(() -> {
+                    try {
+                        String responseData = response.body().string();
+                        if (response.body() == null) {
+                            Log.d(TAG, "responseData in sendBlockUserRequest is null");
+                        } else {
+                            Log.d(TAG, "responseData in sendBlockUserRequest is " + responseData);
+                            chats.remove(entry);
+                            notifyDataSetChanged();
+                        }
+                    }
+                    catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+            }
+        });
+    }
+
     public static class ChatListHolder extends RecyclerView.ViewHolder {
         CircleImageView imageView;
         TextView nameView;
+        ImageButton blockView;
 
         ChatListHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.chat_row_image);
             nameView = itemView.findViewById(R.id.chat_row_name);
+            blockView = itemView.findViewById(R.id.chat_row_block);
         }
     }
 }

--- a/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
@@ -8,6 +8,7 @@ public class Constants {
     final static String listingByListingIdEndpoint = "/api/listings/"; // GET/PUT, needs listing_id appended. POST does not.
     final static String userEndpoint = "/api/users/"; // GET/PUT/DELETE needs user_id appended. POST does not.
     final static String chatsByUserIdEndpoint = "/api/chat/conversations/user/"; // GET needs user_id appended.
+    final static String blockByUserIdEndpoint = "/block"; // POST needs user_id appended beforehand and request body.
     final static String matchesByUserIdEndpoint = "/recommendations/users"; // GET needs user_id appended beforehand. POST needs request body.
     final static String loginEndpoint = "/api/users/login"; // POST
     final static String firebaseTokenEndpoint = "/api/firebase_token";

--- a/frontend/app/src/main/res/drawable/ic_block.xml
+++ b/frontend/app/src/main/res/drawable/ic_block.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#FF0000"
+<vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM4,12c0,-4.42 3.58,-8 8,-8 1.85,0 3.55,0.63 4.9,1.69L5.69,16.9C4.63,15.55 4,13.85 4,12zM12,20c-1.85,0 -3.55,-0.63 -4.9,-1.69L18.31,7.1C19.37,8.45 20,10.15 20,12c0,4.42 -3.58,8 -8,8z"/>

--- a/frontend/app/src/main/res/layout/row_chat.xml
+++ b/frontend/app/src/main/res/layout/row_chat.xml
@@ -31,5 +31,15 @@
             android:textColor="@color/black"
             android:textSize="18sp" />
 
+        <ImageButton
+            android:id="@+id/chat_row_block"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_alignParentEnd="true"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="4dp"
+            android:contentDescription="@string/chat_row_block_text"
+            android:src="@drawable/ic_block" />
+
     </RelativeLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #64 

## Description of the change:
*This change allows a user to click on the block icon in ChatFragment and block a user so the blocked user is no longer visible to the current user. Clicking the icon opens a pop-up that asks the user to confirm the block.*

## How to manually test:
1. Connect to MongoDB
2. Run `npm run dev`
3. To test locally, temporarily change the `baseServerURL` in `Constants.java` to be "https://10.0.2.2:3000"
4. Make sure your `cert.pem` in the `backend` folder matches the one you have in the `/res/raw` folder
5. Also ensure you have the `.env.development` file (in the `backend` folder) and `serviceAccountKey.json` (in the `certs` folder) set up correctly
6. Check to make sure the collections on MongoDB have other users that you can match and chat with
7. Swipe right on another user and click on the chat icon in the bottom nav bar
8. Click on the block icon beside the name of the user you want to block
9. This should open up a pop-up; click `Yes` on the pop-up
10. You should no longer be able to see the user you have just blocked in the ChatFragment or in the MatchesFragment
