### PR TITLE
feat(user): Unmatch user and small fix to block user for conversation deletion

### DIFF
--- a/backend/src/chat/messageStore.js
+++ b/backend/src/chat/messageStore.js
@@ -47,7 +47,6 @@ class MessageStore {
         const conversations = await Conversation.find({ users: userId });
         return conversations;
     }
-    
 
     async deleteConversation(userId1, userId2) {
         return await Conversation.findOneAndDelete({

--- a/backend/src/chat/messageStore.js
+++ b/backend/src/chat/messageStore.js
@@ -47,6 +47,13 @@ class MessageStore {
         const conversations = await Conversation.find({ users: userId });
         return conversations;
     }
+    
+
+    async deleteConversation(userId1, userId2) {
+        return await Conversation.findOneAndDelete({
+            users: { $all: [userId1, userId2] },
+        });
+    }
 }
 
 let messageStore = Object.freeze(new MessageStore());

--- a/backend/src/models/listingModel.js
+++ b/backend/src/models/listingModel.js
@@ -48,9 +48,9 @@ const ListingSchema = new mongoose.Schema({
         },
     },
     images: [{ type: String }],
-    scamReportCount : {
+    scamReportCount: {
         type: Number,
-        default: 0
+        default: 0,
     },
 });
 

--- a/backend/src/models/userModel.js
+++ b/backend/src/models/userModel.js
@@ -64,7 +64,7 @@ const UserSchema = new mongoose.Schema({
     },
     blockedCount: {
         type: Number,
-        default: 0
+        default: 0,
     },
 });
 

--- a/backend/src/routes/listings.js
+++ b/backend/src/routes/listings.js
@@ -68,7 +68,7 @@ router.put('/:listingId', async (req, res, next) => {
 /**
  * Report a specific listing as scam. As a side effect, if a listing is reported by more than BLOCK_THRESHOLD number
  * of users, then the user account and all relevant information for this user will be deleted.
- * 
+ *
  * Route: POST /api/listings/:listingId/report
  *
  * Body: {reporterId: ""}
@@ -78,22 +78,22 @@ router.post('/:listingId/report', async (req, res, next) => {
     let currentUser = await User.findById(req.body.reporterId);
     let reportedListing = await Listing.findById(req.params.listingId);
 
-    if(currentUser && reportedListing){
+    if (currentUser && reportedListing) {
         // If both objects are non-null can update both safely
         await User.findByIdAndUpdate(
-          req.body.reporterId,
-          { $push: { reportedScam: req.params.listingId } },
-          { new: true }
+            req.body.reporterId,
+            { $push: { reportedScam: req.params.listingId } },
+            { new: true },
         );
         let updatedListing = await Listing.findByIdAndUpdate(
             req.params.listingId,
             { $inc: { scamReportCount: 1 } },
-            { new: true }
+            { new: true },
         );
-        if(updatedListing.scamReportCount >= SCAM_THRESHOLD){
+        if (updatedListing.scamReportCount >= SCAM_THRESHOLD) {
             await Listing.findByIdAndDelete(req.params.listingId);
         }
-        res.status(200).json({ message: 'Listing reported successfully!' }); 
+        res.status(200).json({ message: 'Listing reported successfully!' });
     } else {
         res.status(404).json({ error: 'Listing reporting failed!' });
     }

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -114,7 +114,7 @@ router.put('/:userId/recommendations/users', async (req, res, next) => {
         { $push: { notRecommended: req.body.excludedId } },
         { new: true },
     );
-    
+
     // Update list for second user
     matchUser = await User.updateOne(
         { _id: req.body.excludedId },
@@ -144,7 +144,10 @@ router.get('/:userId/recommendations/listings', async (req, res, next) => {
         return res.status(404).json({ error: 'No preferences found for given user!' });
     }
     const loggedInUser = await User.findById(req.params.userId);
-    const tentativeMatchListings = await Listing.find({ userId: { $ne: req.params.userId }, _id: { $nin: loggedInUser.reportedScam } }).lean();
+    const tentativeMatchListings = await Listing.find({
+        userId: { $ne: req.params.userId },
+        _id: { $nin: loggedInUser.reportedScam },
+    }).lean();
     if (tentativeMatchListings) {
         let scores = generateListingScores(userPreferences, tentativeMatchListings);
 

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -98,7 +98,7 @@ router.put('/:userId', async (req, res, next) => {
  * Block a specified user and remove it from the list of possible recommendations of the user who
  * requested the block. As a side effect, if a user is blocked by more than BLOCK_THRESHOLD number
  * of users, then the user account and all relevant information for this user will be deleted.
- * 
+ *
  * Route: POST /api/users/:userId/block
  *
  * Body: {blockedId: ""}
@@ -108,7 +108,7 @@ router.post('/:userId/block', async (req, res, next) => {
     let currentUser = await User.findById(req.params.userId);
     let blockedUser = await User.findById(req.body.blockedId);
 
-    if(currentUser && blockedUser){
+    if (currentUser && blockedUser) {
         await User.findByIdAndUpdate(
             req.params.userId,
             { $push: { notRecommended: req.body.blockedId } },
@@ -121,7 +121,7 @@ router.post('/:userId/block', async (req, res, next) => {
             { new: true },
         );
 
-        if(updatedBlocked.blockedCount >= BLOCK_THRESHOLD){
+        if (updatedBlocked.blockedCount >= BLOCK_THRESHOLD) {
             const deleteUserId = req.body.blockedId;
             await User.findByIdAndDelete(deleteUserId);
             await Listing.deleteMany({ deleteUserId });
@@ -138,10 +138,10 @@ router.post('/:userId/block', async (req, res, next) => {
 });
 
 /**
- * Unmatch two currently matched users. This will delete the conversation between the users 
- * and will also remove users from their excluded lists so that users can now appear on each others 
+ * Unmatch two currently matched users. This will delete the conversation between the users
+ * and will also remove users from their excluded lists so that users can now appear on each others
  * recommendations again.
- * 
+ *
  * Route: POST /api/users/:userId/unmatch
  *
  * Body: {unmatchedId: ""}
@@ -150,7 +150,7 @@ router.post('/:userId/unmatch', async (req, res, next) => {
     let firstUser = await User.findById(req.params.userId);
     let secondUser = await User.findById(req.body.unmatchedId);
 
-    if(firstUser && secondUser){
+    if (firstUser && secondUser) {
         await User.findByIdAndUpdate(
             req.params.userId,
             { $pull: { notRecommended: req.body.unmatchedId } },
@@ -165,7 +165,7 @@ router.post('/:userId/unmatch', async (req, res, next) => {
 
         // If there exists a conversation between users it will be deleted
         await messageStore.deleteConversation(req.params.userId, req.body.unmatchedId);
-        
+
         res.status(200).json({ message: 'Unmatched with user successfully!' });
     } else {
         res.status(404).json({ error: 'User blocking failed!' });


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #111 

## Description of the change:
Add new endpoint to allow users to unmatch with other users. This will put the unmatched users as possible "matches" back again. See endpoint details:
```shell
POST https://localhost:3000/api/users/:userId/unmatch
{
    "unmatchedId": ObjectId("...")
}
```

Add small fix to block functionality so that upon a block, if a conversation between users exists, it will be deleted.

## How to manually test:
1. *Run `npm run dev`*
2. You can use the new Postman Route added under the User directory of the VanRoomies collection `POST Unmatch Users`
