### PR TITLE
feat(match): Add functionality for unmatching with user

### DIFF
--- a/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
@@ -79,7 +79,7 @@ public class ChatListAdapter extends RecyclerView.Adapter {
             ((ChatListHolder) holder).imageView.setImageResource(R.drawable.ic_profile);
         }
         
-        ((ChatListHolder) holder).deleteView.setOnClickListener(v -> showDeleteChatAlert(entry));
+        ((ChatListHolder) holder).unmatchView.setOnClickListener(v -> showUnmatchUserAlert(entry));
         ((ChatListHolder) holder).blockView.setOnClickListener(v -> showBlockUserAlert(entry));
 
         holder.itemView.setOnClickListener(v -> {
@@ -91,15 +91,15 @@ public class ChatListAdapter extends RecyclerView.Adapter {
         });
     }
 
-    private void showDeleteChatAlert(Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
+    private void showUnmatchUserAlert(Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setMessage("Are you sure you want to delete your chat with " + entry.getKey().getFirstName() + " " + entry.getKey().getLastName() + " permanently?")
+        builder.setMessage("Are you sure you want to unmatch with " + entry.getKey().getFirstName() + " " + entry.getKey().getLastName() + "? You will lose your chat with them permanently.")
                 .setPositiveButton("Yes", (dialog, which) -> {
-                    Log.d(TAG, "Sending delete chat request");
-                    sendDeleteChatRequest(httpClient, fragmentActivity, entry);
+                    Log.d(TAG, "Sending unmatch user request");
+                    sendUnmatchUserRequest(httpClient, fragmentActivity, entry);
                 })
                 .setNegativeButton("No", (dialog, which) -> {
-                    Log.d(TAG, "Dismissing dialog for delete chat");
+                    Log.d(TAG, "Dismissing dialog for unmatch user");
                     dialog.dismiss();
                 });
 
@@ -107,12 +107,11 @@ public class ChatListAdapter extends RecyclerView.Adapter {
         alertDialog.show();
     }
 
-    private void sendDeleteChatRequest(OkHttpClient httpClient, FragmentActivity fragmentActivity, Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
-        String url = Constants.baseServerURL + Constants.chatsByUserIdEndpoint + userId;
-        Log.d(TAG, "Delete chat for userId " + entry.getKey().get_id());
+    private void sendUnmatchUserRequest(OkHttpClient httpClient, FragmentActivity fragmentActivity, Map.Entry<UserProfile, ArrayList<ChatMessage>> entry) {
+        String url = Constants.baseServerURL + Constants.userEndpoint + userId + Constants.unmatchByUserIdEndpoint;
+        Log.d(TAG, "Unmatch with userId " + entry.getKey().get_id());
         RequestBody requestBody = new FormBody.Builder()
-                .add("to", entry.getKey().get_id())
-                .add("inactive", String.valueOf(true))
+                .add("unmatchedId", entry.getKey().get_id())
                 .build();
         Request request = new Request.Builder()
                 .url(url)
@@ -130,9 +129,9 @@ public class ChatListAdapter extends RecyclerView.Adapter {
                     try {
                         String responseData = response.body().string();
                         if (response.body() == null) {
-                            Log.d(TAG, "responseData in sendDeleteChatRequest is null");
+                            Log.d(TAG, "responseData in sendUnmatchUserRequest is null");
                         } else {
-                            Log.d(TAG, "responseData in sendDeleteChatRequest is " + responseData);
+                            Log.d(TAG, "responseData in sendUnmatchUserRequest is " + responseData);
                             chats.remove(entry);
                             notifyDataSetChanged();
                         }
@@ -202,14 +201,14 @@ public class ChatListAdapter extends RecyclerView.Adapter {
     public static class ChatListHolder extends RecyclerView.ViewHolder {
         CircleImageView imageView;
         TextView nameView;
-        ImageButton deleteView;
+        ImageButton unmatchView;
         ImageButton blockView;
 
         ChatListHolder(@NonNull View itemView) {
             super(itemView);
             imageView = itemView.findViewById(R.id.chat_row_image);
             nameView = itemView.findViewById(R.id.chat_row_name);
-            deleteView = itemView.findViewById(R.id.chat_row_delete);
+            unmatchView = itemView.findViewById(R.id.chat_row_unmatch);
             blockView = itemView.findViewById(R.id.chat_row_block);
         }
     }

--- a/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ChatListAdapter.java
@@ -115,7 +115,7 @@ public class ChatListAdapter extends RecyclerView.Adapter {
                 .build();
         Request request = new Request.Builder()
                 .url(url)
-                .put(requestBody)
+                .post(requestBody)
                 .build();
         httpClient.newCall(request).enqueue(new Callback() {
             @Override

--- a/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
     final static String chatsByUserIdEndpoint = "/api/chat/conversations/user/"; // GET needs user_id appended.
     final static String blockByUserIdEndpoint = "/block"; // POST needs user_id appended beforehand and request body.
     final static String matchesByUserIdEndpoint = "/recommendations/users"; // GET needs user_id appended beforehand. POST needs request body.
+    final static String unmatchByUserIdEndpoint = "/unmatch"; // POST needs user_id appended beforehand and request body.
     final static String loginEndpoint = "/api/users/login"; // POST
     final static String firebaseTokenEndpoint = "/api/firebase_token";
 

--- a/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
@@ -36,7 +36,6 @@ public class MatchesFragment extends Fragment {
     private String thisUserId;
     private OkHttpClient httpClient;
     private Gson gson;
-    private MatchDeckAdapter matchDeckAdapter;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -64,7 +63,7 @@ public class MatchesFragment extends Fragment {
     }
 
     private void updateMatchesFragmentLayout(View v) {
-        matchDeckAdapter = new MatchDeckAdapter(v.getContext(), userMatches);
+        MatchDeckAdapter matchDeckAdapter = new MatchDeckAdapter(v.getContext(), userMatches);
         cardStack.setAdapter(matchDeckAdapter);
 
         cardStack.setEventCallback(new SwipeDeck.SwipeEventCallback() {

--- a/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
@@ -36,6 +36,7 @@ public class MatchesFragment extends Fragment {
     private String thisUserId;
     private OkHttpClient httpClient;
     private Gson gson;
+    private MatchDeckAdapter matchDeckAdapter;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -63,7 +64,7 @@ public class MatchesFragment extends Fragment {
     }
 
     private void updateMatchesFragmentLayout(View v) {
-        MatchDeckAdapter matchDeckAdapter = new MatchDeckAdapter(v.getContext(), userMatches);
+        matchDeckAdapter = new MatchDeckAdapter(v.getContext(), userMatches);
         cardStack.setAdapter(matchDeckAdapter);
 
         cardStack.setEventCallback(new SwipeDeck.SwipeEventCallback() {
@@ -81,7 +82,9 @@ public class MatchesFragment extends Fragment {
 
             @Override
             public void cardsDepleted() {
-                Log.d(TAG, "No more matches");
+                Log.d(TAG, "Fetching more matches");
+                Toast.makeText(getActivity(), R.string.reshow_matches, Toast.LENGTH_SHORT).show();
+                getAllMatches(httpClient, getActivity(), v);
             }
 
             @Override

--- a/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/ViewListingActivity.java
@@ -7,7 +7,6 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;

--- a/frontend/app/src/main/res/drawable/ic_delete.xml
+++ b/frontend/app/src/main/res/drawable/ic_delete.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#000000"
-    android:viewportHeight="24" android:viewportWidth="24"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
-</vector>

--- a/frontend/app/src/main/res/drawable/ic_unmatch.xml
+++ b/frontend/app/src/main/res/drawable/ic_unmatch.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M16.5,3c-0.96,0 -1.9,0.25 -2.73,0.69L12,9h3l-3,10l1,-9h-3l1.54,-5.39C10.47,3.61 9.01,3 7.5,3C4.42,3 2,5.42 2,8.5c0,4.13 4.16,7.18 10,12.5c5.47,-4.94 10,-8.26 10,-12.5C22,5.42 19.58,3 16.5,3z"/>
+</vector>

--- a/frontend/app/src/main/res/layout/row_chat.xml
+++ b/frontend/app/src/main/res/layout/row_chat.xml
@@ -13,12 +13,12 @@
 
         <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/chat_row_image"
-            android:layout_width="70dp"
-            android:layout_height="70dp"
+            android:layout_width="66dp"
+            android:layout_height="58dp"
             android:src="@drawable/ic_profile"
-            app:civ_border_width="2dp"
             app:civ_border_color="#000000"
-            app:civ_border_overlay= "false" />
+            app:civ_border_overlay="false"
+            app:civ_border_width="2dp" />
 
         <TextView
             android:id="@+id/chat_row_name"
@@ -30,6 +30,16 @@
             android:text="@string/chat_row_name_text"
             android:textColor="@color/black"
             android:textSize="18sp" />
+
+        <ImageButton
+            android:id="@+id/chat_row_delete"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="3dp"
+            android:layout_toStartOf="@+id/chat_row_block"
+            android:contentDescription="@string/chat_row_delete_text"
+            android:src="@drawable/ic_delete" />
 
         <ImageButton
             android:id="@+id/chat_row_block"

--- a/frontend/app/src/main/res/layout/row_chat.xml
+++ b/frontend/app/src/main/res/layout/row_chat.xml
@@ -32,13 +32,13 @@
             android:textSize="18sp" />
 
         <ImageButton
-            android:id="@+id/chat_row_delete"
+            android:id="@+id/chat_row_unmatch"
             android:layout_width="60dp"
             android:layout_height="60dp"
             android:layout_gravity="center_vertical"
             android:layout_marginEnd="3dp"
             android:layout_toStartOf="@+id/chat_row_block"
-            android:contentDescription="@string/chat_row_delete_text"
+            android:contentDescription="@string/chat_row_unmatch_text"
             android:src="@drawable/ic_unmatch" />
 
         <ImageButton

--- a/frontend/app/src/main/res/layout/row_chat.xml
+++ b/frontend/app/src/main/res/layout/row_chat.xml
@@ -39,7 +39,7 @@
             android:layout_marginEnd="3dp"
             android:layout_toStartOf="@+id/chat_row_block"
             android:contentDescription="@string/chat_row_delete_text"
-            android:src="@drawable/ic_delete" />
+            android:src="@drawable/ic_unmatch" />
 
         <ImageButton
             android:id="@+id/chat_row_block"

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="matches_bio_string">Bio</string>
     <string name="matches_instruction_string">Swipe right to match, and left to reject</string>
     <string name="no_matches_found">Sorry, no matches found!</string>
+    <string name="reshow_matches">Fetching you more matches!</string>
 
     <!-- Chat Channel Activity -->
     <string name="chat_send_button_text">Send</string>

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
 
     <!-- Chat Row -->
     <string name="chat_row_name_text">Their Name</string>
-    <string name="chat_row_delete_text">Delete Chat</string>
+    <string name="chat_row_unmatch_text">Unmatch with User</string>
     <string name="chat_row_block_text">Block User</string>
 
     <!-- Profile Fragment -->

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
 
     <!-- Chat Row -->
     <string name="chat_row_name_text">Their Name</string>
+    <string name="chat_row_delete_text">Delete Chat</string>
     <string name="chat_row_block_text">Block User</string>
 
     <!-- Profile Fragment -->


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #75 

## Description of the change:
*This change allows a user to click on the broken heart icon in ChatFragment and unmatch with a user so the current chat with the other user is deleted. Clicking the icon opens a pop-up that asks the user to confirm the block. The user will still be able to match with this user again in the future.*

*This change also includes a small fix such that when all the cards in the card deck inside MatchesFragment are depleted, the app automatically fetches more matches again.*

## How to manually test:
1. Connect to MongoDB
2. Run `npm run dev`
3. To test locally, temporarily change the `baseServerURL` in `Constants.java` to be "https://10.0.2.2:3000"
4. Make sure your `cert.pem` in the `backend` folder matches the one you have in the `/res/raw` folder
5. Also ensure you have the `.env.development` file (in the `backend` folder) and `serviceAccountKey.json` (in the `certs` folder) set up correctly
6. Check to make sure the collections on MongoDB have other users that you can match and chat with
7. Swipe right on another user and click on the chat icon in the bottom nav bar
8. Click on the broken heart (unmatch) icon beside the name of the user you want to unmatch with
9. This should open up a pop-up; click `Yes` on the pop-up
10. You should no longer be able to see the user you have just unmatched with in the ChatFragment
11. Click on MatchesFragment again and keep swiping till you see the user just unmatched with; you should be able to see them there.