### PR TITLE
feat(enhancement): Save State in Matches

### DIFF
--- a/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/MatchesFragment.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.os.StrictMode;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -38,6 +39,14 @@ public class MatchesFragment extends Fragment {
     private Gson gson;
 
     @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        // Save the necessary data to the bundle
+        outState.putParcelableArrayList("userMatches", userMatches);
+        // You might need to save other state information if needed
+    }
+
+    @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         StrictMode.ThreadPolicy policy = new StrictMode.ThreadPolicy.Builder().permitAll().build();
@@ -55,10 +64,20 @@ public class MatchesFragment extends Fragment {
 
         httpClient = HTTPSClientFactory.createClient(getActivity().getApplication());
         gson = new Gson();
-        userMatches = new ArrayList<>();
         cardStack = v.findViewById(R.id.matches_swipe_deck);
+        userMatches = new ArrayList<>();
 
-        getAllMatches(httpClient, getActivity(), v);
+        if (savedInstanceState != null) {
+            ArrayList<Parcelable> parcelableArrayList = savedInstanceState.getParcelableArrayList("userMatches");
+            if (parcelableArrayList != null) {
+                userMatches = (ArrayList<UserProfile>) ((ArrayList) parcelableArrayList);
+                updateMatchesFragmentLayout(v);
+            }
+        }
+        else {
+            getAllMatches(httpClient, getActivity(), v);
+        }
+
         return v;
     }
 

--- a/frontend/app/src/main/java/com/chads/vanroomies/UserProfile.java
+++ b/frontend/app/src/main/java/com/chads/vanroomies/UserProfile.java
@@ -1,8 +1,11 @@
 package com.chads.vanroomies;
 
+import android.os.Parcel;
+import android.os.Parcelable;
+
 import java.io.Serializable;
 
-public class UserProfile implements Serializable {
+public class UserProfile implements Parcelable {
     private String _id;
     private String firstName;
     private String lastName;
@@ -46,5 +49,42 @@ public class UserProfile implements Serializable {
 
     public void setProfilePicture(String profilePicture) {
         this.profilePicture = profilePicture;
+    }
+
+    // Parcelable implementation methods
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(_id);
+        dest.writeString(firstName);
+        dest.writeString(lastName);
+        dest.writeString(bio);
+        dest.writeString(profilePicture);
+    }
+
+    // Parcelable Creator
+    public static final Parcelable.Creator<UserProfile> CREATOR = new Parcelable.Creator<UserProfile>() {
+        @Override
+        public UserProfile createFromParcel(Parcel in) {
+            return new UserProfile(in);
+        }
+
+        @Override
+        public UserProfile[] newArray(int size) {
+            return new UserProfile[size];
+        }
+    };
+
+    // Constructor for Parcelable
+    private UserProfile(Parcel in) {
+        _id = in.readString();
+        firstName = in.readString();
+        lastName = in.readString();
+        bio = in.readString();
+        profilePicture = in.readString();
     }
 }


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #106 

## Description of the change:
*This change saves state in the Matches Fragment so that when users click away from the fragment, they can see the last card on the card deck before they click away.*

## How to manually test:
1. Connect to MongoDB
2. Run `npm run dev`
3. To test locally, temporarily change the `baseServerURL` in `Constants.java` to be "https://10.0.2.2:3000"
4. Make sure your `cert.pem` in the `backend` folder matches the one you have in the `/res/raw` folder
5. Also ensure you have the `.env.development` file (in the `backend` folder) and `serviceAccountKey.json` (in the `certs` folder) set up correctly
6. Check to make sure the collections on MongoDB have other users that you can match with
7. Swipe left on a user in the matches fragment and note down the name of the second match
8. Click on a different fragment then click back on the matches fragment
9. You should be able to pick up from where you left off
