### PR TITLE
bug(be): Fix ID duplication in exclusion/reported lists

### DIFF
--- a/backend/src/routes/listings.js
+++ b/backend/src/routes/listings.js
@@ -87,7 +87,7 @@ router.post('/:listingId/report', async (req, res, next) => {
         // If both objects are non-null can update both safely
         await User.findByIdAndUpdate(
             req.body.reporterId,
-            { $push: { reportedScam: req.params.listingId } },
+            { $addToSet: { reportedScam: req.params.listingId } },
             { new: true },
         );
         let updatedListing = await Listing.findByIdAndUpdate(

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -110,13 +110,13 @@ router.put('/:userId/recommendations/users', async (req, res, next) => {
     if (currentUser && matchUser) {
         let updatedUser = await User.findByIdAndUpdate(
             req.params.userId,
-            { $push: { notRecommended: req.body.excludedId } },
+            { $addToSet: { notRecommended: req.body.excludedId } },
             { new: true },
         );
 
         await User.findByIdAndUpdate(
             req.body.excludedId,
-            { $push: { notRecommended: req.params.userId } },
+            { $addToSet: { notRecommended: req.params.userId } },
             { new: true },
         );
         res.status(200).json(updatedUser);

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -100,13 +100,13 @@ router.post('/:userId/block', async (req, res, next) => {
     if (currentUser && blockedUser) {
         await User.findByIdAndUpdate(
             req.params.userId,
-            { $push: { notRecommended: req.body.blockedId } },
+            { $addToSet: { notRecommended: req.body.blockedId } },
             { new: true },
         );
 
         let updatedBlocked = await User.findByIdAndUpdate(
             req.body.blockedId,
-            { $push: { notRecommended: req.params.userId }, $inc: { blockedCount: 1 } },
+            { $addToSet: { notRecommended: req.params.userId }, $inc: { blockedCount: 1 } },
             { new: true },
         );
         if (updatedBlocked.blockedCount >= BLOCK_THRESHOLD) {


### PR DESCRIPTION
# Welcome to VanRoomies! 👋✈️

Fixes: #140 

## Description of the change:
This changes fixes the problem wherein IDs can be duplicated when exluding or blocking or reporting entities. Although neither of these scenarios can actually occur because of FE restrictions of what can be and cannot be seen, we want to ensure the system is robust in and on its own.

## How to manually test:
NA
